### PR TITLE
#392 handling of unknown log level

### DIFF
--- a/rultor-conveyer/src/main/java/com/rultor/log4j/GroupAppender.java
+++ b/rultor-conveyer/src/main/java/com/rultor/log4j/GroupAppender.java
@@ -138,12 +138,28 @@ final class GroupAppender extends AppenderSkeleton
             this.lines.add(
                 new Drain.Line.Simple(
                     new Time().delta(this.start),
-                    GroupAppender.LEVELS.get(event.getLevel()),
+                    this.level(event.getLevel()),
                     msg
                 ).toString()
             );
             this.radar.append(msg);
         }
+    }
+
+    /**
+     * Convert log4j logging level to java.util.logging one.
+     * When log4j level is unknown it will return Level.INFO.
+     * @param level Log4j logging level.
+     * @return Level in java.util.logging.
+     */
+    private java.util.logging.Level level(final Level level) {
+        final java.util.logging.Level jlevel;
+        if (GroupAppender.LEVELS.containsKey(level)) {
+            jlevel = GroupAppender.LEVELS.get(level);
+        } else {
+            jlevel = java.util.logging.Level.INFO;
+        }
+        return jlevel;
     }
 
     @Override

--- a/rultor-conveyer/src/test/java/com/rultor/log4j/GroupAppenderTest.java
+++ b/rultor-conveyer/src/test/java/com/rultor/log4j/GroupAppenderTest.java
@@ -42,8 +42,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.log4j.PatternLayout;
+import org.apache.log4j.SimpleLayout;
 import org.apache.log4j.spi.LoggingEvent;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -200,4 +202,19 @@ public final class GroupAppenderTest {
         );
     }
 
+    /**
+     * GroupAppender should use a default log level when it receives an unknown
+     * one.
+     */
+    @Test
+    public void logsMessagesWithWrongLogLevel() {
+        final Drain drain = Mockito.mock(Drain.class);
+        final LoggingEvent event = Mockito.mock(LoggingEvent.class);
+        final Level level = Mockito.mock(Level.class);
+        Mockito.when(event.getLevel()).thenReturn(level);
+        final GroupAppender appender = new GroupAppender(new Time(), drain);
+        appender.setLayout(new SimpleLayout());
+        appender.append(event);
+        Mockito.verify(event, Mockito.atLeast(1)).getLevel();
+    }
 }


### PR DESCRIPTION
I've added a default log level (Level.INFO) that will be used when unknown Log4j log level is seen
