### PR TITLE
Issue-588. Md5 for Linux fixed.

### DIFF
--- a/src/test/java/com/rultor/agents/daemons/StartsDaemonITCase.java
+++ b/src/test/java/com/rultor/agents/daemons/StartsDaemonITCase.java
@@ -48,6 +48,7 @@ import org.apache.commons.lang3.CharEncoding;
 import org.apache.commons.lang3.SystemUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -75,9 +76,11 @@ public final class StartsDaemonITCase {
     /**
      * StartsDaemon can start a daemon.
      * @throws Exception In case of error.
+     * @checkstyle ExecutableStatementCountCheck (50 lines)
      */
     @Test
     public void startsDaemon() throws Exception {
+        Assume.assumeFalse(SystemUtils.IS_OS_WINDOWS);
         final Sshd sshd = new Sshd(this.temp.newFolder());
         final int port = sshd.start();
         final Talk talk = new Talk.InFile();


### PR DESCRIPTION
I'm not 100% sure should I add something for Windows here. Because, as far as I know Windows have no such utility by default(https://help.ubuntu.com/community/HowToMD5SUM#MD5SUM_on_Windows). The problem was reported for Linux, I've fixed it. Now it should works correctly on MacOS and Linux.
