### PR TITLE
Incomplete documentation: Prerequisites for running Rultor tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -366,11 +366,11 @@
                         <phase>validate</phase>
                         <configuration>
                             <rules>
-                                <!-- @todo #686 Check if Rultor can be built on mac and loosen this rule if needed -->
                                 <requireOS>
                                     <family>unix</family>
+                                    <family>mac</family>
                                     <message>
-                                        You should use Unix-like OS to successfully build Rultor.
+                                        You should use Unix-like or Mac OS to successfully build Rultor.
                                         With an other OS you are still able to check sources with the command:
                                         'mvn qulice:check -Pqulice'
                                     </message>

--- a/pom.xml
+++ b/pom.xml
@@ -358,26 +358,6 @@
                             </rules>
                         </configuration>
                     </execution>
-                    <execution>
-                        <id>check-os</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <phase>validate</phase>
-                        <configuration>
-                            <rules>
-                                <requireOS>
-                                    <family>unix</family>
-                                    <family>mac</family>
-                                    <message>
-                                        You should use Unix-like or Mac OS to successfully build Rultor.
-                                        With an other OS you are still able to check sources with the command:
-                                        'mvn qulice:check -Pqulice'
-                                    </message>
-                                </requireOS>
-                            </rules>
-                        </configuration>
-                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -875,6 +855,43 @@
                                 <exclude>duplicatefinder:.*</exclude>
                             </excludes>
                         </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>restrict-windows-build</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <version>1.3.1</version>
+                        <executions>
+                            <execution>
+                                <id>fail-on-windows</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <phase>validate</phase>
+                                <configuration>
+                                    <rules>
+                                        <alwaysFail>
+                                            <message>
+                                                You should use Unix-like or Mac OS to successfully build Rultor.
+                                                With an other OS you are still able to check sources with the command:
+                                                'mvn qulice:check -Pqulice'
+                                            </message>
+                                        </alwaysFail>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -358,6 +358,26 @@
                             </rules>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>check-os</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <phase>validate</phase>
+                        <configuration>
+                            <rules>
+                                <!-- @todo #686 Check if Rultor can be built on mac and loosen this rule if needed -->
+                                <requireOS>
+                                    <family>unix</family>
+                                    <message>
+                                        You should use Unix-like OS to successfully build Rultor.
+                                        With an other OS you are still able to check sources with the command:
+                                        'mvn qulice:check -Pqulice'
+                                    </message>
+                                </requireOS>
+                            </rules>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>


### PR DESCRIPTION
Changes for Issue #686
There are multiple errors that don't allow to build Rultor on Windows. I've added a check of OS family to the pom.xml with the message that explains it to not confuse developers.