### PR TITLE
#722 - BuildService interface

### DIFF
--- a/src/main/java/com/rultor/agents/build/BuildService.java
+++ b/src/main/java/com/rultor/agents/build/BuildService.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2009-2015, rultor.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the rultor.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.rultor.agents.build;
+
+import com.jcabi.github.Github;
+
+/**
+ * Build service interface.
+ *
+ * @author Eugene Bukhtin (maurezen@gmail.com)
+ * @version $Id$
+ * @since 1.0
+ *
+ * @todo #722 implement an AppVeyor BuildService, which would send a request to
+ * an AppVeyor instance configured in .rultor.yml to build from the supplied
+ * github repository.
+ */
+public interface BuildService {
+
+    /**
+     * Run a build on a specific repository.
+     * @param repo A github repository to run build on.
+     * @param callback A callback for receving build result.
+     */
+    void build(final Github repo, final BuildServiceCallback callback);
+}

--- a/src/main/java/com/rultor/agents/build/BuildServiceCallback.java
+++ b/src/main/java/com/rultor/agents/build/BuildServiceCallback.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2009-2015, rultor.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the rultor.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.rultor.agents.build;
+
+/**
+ * Build service callback interface.
+ *
+ * @author Eugene Bukhtin (maurezen@gmail.com)
+ * @version $Id$
+ * @since 1.0
+ */
+public interface BuildServiceCallback {
+
+    /**
+     * A method to be called upon build completion.
+     * @param response Build service response.
+     */
+    void buildFinished(Response response);
+}

--- a/src/main/java/com/rultor/agents/build/Response.java
+++ b/src/main/java/com/rultor/agents/build/Response.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2009-2015, rultor.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the rultor.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.rultor.agents.build;
+
+/**
+ * Build service response.
+ *
+ * @author Eugene Bukhtin (maurezen@gmail.com)
+ * @version $Id$
+ * @since 1.0
+ */
+public class Response {
+
+    /**
+     * Message.
+     */
+    private final String message;
+    /**
+     * Build status.
+     */
+    private final Status status;
+
+    /**
+     * Constructor.
+     * @param msg Message.
+     * @param stts Build status.
+     */
+    public Response(final String msg, final Status stts) {
+        this.message = msg;
+        this.status = stts;
+    }
+
+    /**
+     * Message getter.
+     * @return Message.
+     */
+    public final String getMessage() {
+        return this.message;
+    }
+
+    /**
+     * Status getter.
+     * @return Build status.
+     */
+    public final Status getStatus() {
+        return this.status;
+    }
+}

--- a/src/main/java/com/rultor/agents/build/Response.java
+++ b/src/main/java/com/rultor/agents/build/Response.java
@@ -36,16 +36,16 @@ package com.rultor.agents.build;
  * @version $Id$
  * @since 1.0
  */
-public class Response {
+public final class Response {
 
     /**
      * Message.
      */
-    private final String message;
+    private final transient String message;
     /**
      * Build status.
      */
-    private final Status status;
+    private final transient Status status;
 
     /**
      * Constructor.
@@ -61,7 +61,7 @@ public class Response {
      * Message getter.
      * @return Message.
      */
-    public final String getMessage() {
+    public String message() {
         return this.message;
     }
 
@@ -69,7 +69,7 @@ public class Response {
      * Status getter.
      * @return Build status.
      */
-    public final Status getStatus() {
+    public Status status() {
         return this.status;
     }
 }

--- a/src/main/java/com/rultor/agents/build/Status.java
+++ b/src/main/java/com/rultor/agents/build/Status.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2009-2015, rultor.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the rultor.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.rultor.agents.build;
+
+/**
+ * Build status.
+ *
+ * @author Eugene Bukhtin (maurezen@gmail.com)
+ * @version $Id$
+ * @since 1.0
+ */
+public enum Status {
+    /**
+     * Build succeeded.
+     */
+    OK,
+    /**
+     * Build failed.
+     */
+    FAILED;
+}

--- a/src/main/java/com/rultor/agents/build/package-info.java
+++ b/src/main/java/com/rultor/agents/build/package-info.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2009-2015, rultor.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the rultor.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Build service.
+ *
+ * @author Eugene Bukhtin (maurezen@gmail.com)
+ * @version $Id$
+ * @since 1.0
+ */
+package com.rultor.agents.build;

--- a/src/test/java/com/rultor/agents/build/ResponseTest.java
+++ b/src/test/java/com/rultor/agents/build/ResponseTest.java
@@ -47,8 +47,8 @@ public final class ResponseTest {
      */
     @Test
     public void returnsMessage() throws Exception {
-        final Response mock = new Response("A message", Status.OK);
-        Assert.assertEquals(Status.OK, mock.status());
+        final Response response = new Response("A message", Status.OK);
+        Assert.assertEquals(Status.OK, response.status());
     }
 
     /**
@@ -57,7 +57,7 @@ public final class ResponseTest {
      */
     @Test
     public void returnsStatus() throws Exception {
-        final Response mock = new Response("A message", Status.OK);
-        Assert.assertEquals("A message", mock.message());
+        final Response response = new Response("A message", Status.OK);
+        Assert.assertEquals("A message", response.message());
     }
 }

--- a/src/test/java/com/rultor/agents/build/ResponseTest.java
+++ b/src/test/java/com/rultor/agents/build/ResponseTest.java
@@ -29,47 +29,35 @@
  */
 package com.rultor.agents.build;
 
+import junit.framework.Assert;
+import org.junit.Test;
+
 /**
- * Build service response.
+ * Tests for ${@link Response}.
  *
  * @author Eugene Bukhtin (maurezen@gmail.com)
  * @version $Id$
  * @since 1.0
+ * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */
-public final class Response {
-
+public final class ResponseTest {
     /**
-     * Message.
+     * Response can return message.
+     * @throws Exception In case of error.
      */
-    private final transient String msg;
-    /**
-     * Build status.
-     */
-    private final transient Status stts;
-
-    /**
-     * Constructor.
-     * @param message Message.
-     * @param status Build status.
-     */
-    public Response(final String message, final Status status) {
-        this.msg = message;
-        this.stts = status;
+    @Test
+    public void returnsMessage() throws Exception {
+        final Response mock = new Response("A message", Status.OK);
+        Assert.assertEquals(Status.OK, mock.status());
     }
 
     /**
-     * Message getter.
-     * @return Message.
+     * Response can return status.
+     * @throws Exception In case of error.
      */
-    public String message() {
-        return this.msg;
-    }
-
-    /**
-     * Status getter.
-     * @return Build status.
-     */
-    public Status status() {
-        return this.stts;
+    @Test
+    public void returnsStatus() throws Exception {
+        final Response mock = new Response("A message", Status.OK);
+        Assert.assertEquals("A message", mock.message());
     }
 }

--- a/src/test/java/com/rultor/agents/build/ResponseTest.java
+++ b/src/test/java/com/rultor/agents/build/ResponseTest.java
@@ -29,7 +29,8 @@
  */
 package com.rultor.agents.build;
 
-import junit.framework.Assert;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
@@ -48,7 +49,10 @@ public final class ResponseTest {
     @Test
     public void returnsMessage() throws Exception {
         final Response response = new Response("A message", Status.OK);
-        Assert.assertEquals(Status.OK, response.status());
+        MatcherAssert.assertThat(
+            response.status(),
+            Matchers.equalTo(Status.OK)
+        );
     }
 
     /**
@@ -58,6 +62,9 @@ public final class ResponseTest {
     @Test
     public void returnsStatus() throws Exception {
         final Response response = new Response("A message", Status.OK);
-        Assert.assertEquals("A message", response.message());
+        MatcherAssert.assertThat(
+            response.message(),
+            Matchers.equalTo("A message")
+        );
     }
 }

--- a/src/test/java/com/rultor/agents/build/package-info.java
+++ b/src/test/java/com/rultor/agents/build/package-info.java
@@ -27,49 +27,12 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.rultor.agents.build;
 
 /**
- * Build service response.
+ * Build service tests.
  *
  * @author Eugene Bukhtin (maurezen@gmail.com)
  * @version $Id$
  * @since 1.0
  */
-public final class Response {
-
-    /**
-     * Message.
-     */
-    private final transient String msg;
-    /**
-     * Build status.
-     */
-    private final transient Status stts;
-
-    /**
-     * Constructor.
-     * @param message Message.
-     * @param status Build status.
-     */
-    public Response(final String message, final Status status) {
-        this.msg = message;
-        this.stts = status;
-    }
-
-    /**
-     * Message getter.
-     * @return Message.
-     */
-    public String message() {
-        return this.msg;
-    }
-
-    /**
-     * Status getter.
-     * @return Build status.
-     */
-    public Status status() {
-        return this.stts;
-    }
-}
+package com.rultor.agents.build;


### PR DESCRIPTION
@yegor256 having a think about this now. Where do I complain loudly about documentation? It is patchy. Also, I would very much appreciate an overview of the project architecture. 

Anyway, let's go on. My suggestions this far:
 - We can add an additional section right away, the parser will not break.
 - We need to add the code to interpret the added services section.
 - We have the code to run the arbitrary script (in DockerRun).
 - We need the code to run the build process on a service supplied in a service section.Will 'com.rultor.agents.build' do as a location?
  - A build service interface with the method to run it against a supplied github repo, returning build status (preferrably asynchronously).
  - An implementation for AppVeyor, constructed from the info supplied in config, being able to send the actual build request. Seeing as config parsing is just hardcoded everywhere, this probably will be the place for the code to interpret the appveyor service section of the config.
  - The code to wait for the build service response and react to it (post&run scripts or just post).