### PR TITLE
#726 using RepoCommit to get author login

### DIFF
--- a/src/main/java/com/rultor/agents/github/CommentsTag.java
+++ b/src/main/java/com/rultor/agents/github/CommentsTag.java
@@ -32,7 +32,6 @@ package com.rultor.agents.github;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import com.jcabi.aspects.Immutable;
-import com.jcabi.github.Commit;
 import com.jcabi.github.Github;
 import com.jcabi.github.Issue;
 import com.jcabi.github.Release;
@@ -162,12 +161,11 @@ public final class CommentsTag extends AbstractAgent {
             repo.commits().iterate(params)
         );
         for (final RepoCommit.Smart commit : commits) {
-            final Commit cmt = repo.git().commits().get(commit.sha());
             lines.add(
                 String.format(
                     " * %s by @%s: %s",
                     commit.sha(),
-                    cmt.json().getJsonObject("author").get("login"),
+                    commit.json().getJsonObject("author").getString("login"),
                     commit.message().replaceAll("[^\\p{Print}]", " ")
                 )
             );


### PR DESCRIPTION
The problem was that we still use `/git/` version of `Commit`, when I upgraded the jcabi-github (#671) I didn't notice that we were not using `RepoCommit` but `Commit`. So this commit is about coming back to the original implementation which works correctly with jcabi-github fix (jcabi/jcabi-github#943).
I've tested this using my github api key and retrieval of author login works correctly when using `RepoCommit`, bu gives null when using `Commit`.

It would be best to have a test for this, but that would require setting up a mock repository where we could create releases (and commit code, before each release) which seems like an overkill.

