### PR TITLE
DecryptTest.createTestProfileXML: rm spurious space that's breaking tests

### DIFF
--- a/src/test/java/com/rultor/agents/req/DecryptTest.java
+++ b/src/test/java/com/rultor/agents/req/DecryptTest.java
@@ -165,9 +165,12 @@ public final class DecryptTest {
      */
     private XMLDocument createTestProfileXML() {
         return new XMLDocument(
-            Joiner.on(' ').join(
-                "<p><entry key='decrypt'><entry key='a.txt'>",
-                "a.txt.asc</entry></entry></p>"
+            Joiner.on("").join(
+                "<p>",
+                "<entry key='decrypt'>",
+                "<entry key='a.txt'>a.txt.asc</entry>",
+                "</entry>",
+                "</p>"
             )
         );
     }


### PR DESCRIPTION
This fixes the cause of https://github.com/yegor256/rultor/pull/859#issuecomment-107824659
An extra space in the XML was causing an extra space in the filename, thus causing gpg to attempt to open a nonexistent file whose name started with a space character.