### PR TITLE
resources: Improve `config` response

### DIFF
--- a/src/main/resources/phrases_en_US.properties
+++ b/src/main/resources/phrases_en_US.properties
@@ -18,7 +18,7 @@ QnIfCollaborator.denied=You need to add me to the list of collaborators \
     in your Github project. The process is explained [here](http://doc.rultor.com/basics.html)
 
 QnConfig.response=This is how I understand the `.rultor.yml` \
-    file in the root directory of this repository:\n\n```xml\n%s\n```\n\n \
+    file in the root directory of your base branch:\n\n```xml\n%s\n```\n\n \
     [This page](http://doc.rultor.com/reference.html) explains how \
     to configure it.
 


### PR DESCRIPTION
This hints explicitly to the user that the yml file from the base branch
is taken which can be easily forgotten else.

Fixes https://github.com/yegor256/rultor/issues/873