### PR TITLE
Add validations to reject tag releases if the version number is too low #960

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,6 +343,11 @@
             <version>2.0.1</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>3.0.3</version>
+        </dependency>
     </dependencies>
     <build>
         <pluginManagement>

--- a/src/main/java/com/rultor/agents/github/CommentsTag.java
+++ b/src/main/java/com/rultor/agents/github/CommentsTag.java
@@ -115,19 +115,19 @@ public final class CommentsTag extends AbstractAgent {
             Logger.info(this, "duplicate tag %s commented", tag);
         } else if (new Version(tag).isValid() && !priors.isValid()) {
             issue.comments().post(
-                    String.format(
-                            CommentsTag.PHRASES.getString(
-                                    "CommentsTag.version-too-low"
-                            ),
-                            tag,
-                            priors.latest()
-                    )
-            );
-            Logger.info(
-                    this,
-                    "tag %s must be greater than previous version %s",
+                String.format(
+                    CommentsTag.PHRASES.getString(
+                        "CommentsTag.version-too-low"
+                    ),
                     tag,
                     priors.latest()
+                )
+            );
+            Logger.info(
+                this,
+                "tag %s must be greater than previous version %s",
+                tag,
+                priors.latest()
             );
         } else {
             final Repo repo = issue.repo();

--- a/src/main/java/com/rultor/agents/github/CommentsTag.java
+++ b/src/main/java/com/rultor/agents/github/CommentsTag.java
@@ -113,7 +113,7 @@ public final class CommentsTag extends AbstractAgent {
                 )
             );
             Logger.info(this, "duplicate tag %s commented", tag);
-        } else if (new Version(tag).isValid() && !priors.isTagValid()) {
+        } else if (new Version(tag).isValid() && !priors.isValid()) {
             issue.comments().post(
                     String.format(
                             CommentsTag.PHRASES.getString(

--- a/src/main/java/com/rultor/agents/github/CommentsTag.java
+++ b/src/main/java/com/rultor/agents/github/CommentsTag.java
@@ -133,14 +133,14 @@ public final class CommentsTag extends AbstractAgent {
                                     "CommentsTag.version-to-low"
                             ),
                             tag,
-                            previous.toString()
+                            Collections.max(previous)
                     )
             );
             Logger.info(
                     this,
                     "tag %s must be greater than previous version %s",
                     tag,
-                    previous
+                    Collections.max(previous)
             );
         } else {
             final Repo repo = issue.repo();

--- a/src/main/java/com/rultor/agents/github/CommentsTag.java
+++ b/src/main/java/com/rultor/agents/github/CommentsTag.java
@@ -126,7 +126,7 @@ public final class CommentsTag extends AbstractAgent {
             );
             Logger.info(this, "duplicate tag %s commented", tag);
         } else if (this.isVersionValid(tag)
-                && this.isReleaseValid(tag, previous)) {
+                && !this.isReleaseValid(tag, previous)) {
             issue.comments().post(
                     String.format(
                             CommentsTag.PHRASES.getString(
@@ -198,7 +198,7 @@ public final class CommentsTag extends AbstractAgent {
         } else {
             max = Collections.max(previous);
         }
-        return new DefaultArtifactVersion(tag).compareTo(max) == -1;
+        return new DefaultArtifactVersion(tag).compareTo(max) == 1;
     }
 
     /**

--- a/src/main/java/com/rultor/agents/github/PreviousReleases.java
+++ b/src/main/java/com/rultor/agents/github/PreviousReleases.java
@@ -125,7 +125,7 @@ public final class PreviousReleases {
     private final class ReleaseToVersion
         implements Function<Release, DefaultArtifactVersion> {
         @Override
-        @SuppressWarnings("PMD.OnlyOneReturn")
+        @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
         public DefaultArtifactVersion apply(final Release release) {
             final Release.Smart rel = new Release.Smart(release);
             try {
@@ -133,7 +133,7 @@ public final class PreviousReleases {
                 return new DefaultArtifactVersion(tag);
             } catch (final IOException exception) {
                 Logger.error(this, "IOException caused from rel.tag()");
-                return null;
+                throw new RuntimeException(exception);
             }
         }
     }

--- a/src/main/java/com/rultor/agents/github/PreviousReleases.java
+++ b/src/main/java/com/rultor/agents/github/PreviousReleases.java
@@ -72,10 +72,13 @@ public final class PreviousReleases {
     }
 
     /**
-     * Is this tagged release valid.
+     * Is the proposed tag true, with respect to previous released tags. For
+     * example, if there are previous releases of [0.2,0.5,0.7], and the
+     * proposed tag (version) is .6, this will return false. If the proposed
+     * tag is .8 it will return true.
      * @return True if the release is valid
      */
-    public boolean isTagValid() {
+    public boolean isValid() {
         final DefaultArtifactVersion latest = latest();
         return new DefaultArtifactVersion(this.version.toString())
             .compareTo(latest) == 1;

--- a/src/main/java/com/rultor/agents/github/PreviousReleases.java
+++ b/src/main/java/com/rultor/agents/github/PreviousReleases.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2009-2015, rultor.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the rultor.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.rultor.agents.github;
+
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
+import com.jcabi.aspects.Immutable;
+import com.jcabi.github.Release;
+import com.jcabi.github.Releases;
+import com.jcabi.log.Logger;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+
+/**
+ * Encapsulates a set of previous releases and a currently proposed release.
+ *
+ * @author Jimmy Spivey (JimDeanSpivey@gmail.com)
+ * @version $Id$
+ * @since 1.57
+ */
+@Immutable
+public final class PreviousReleases {
+
+    /**
+     * The proposed tag.
+     */
+    private final transient Version version;
+
+    /**
+     * Previously released tags.
+     */
+    private final transient Releases priors;
+
+    /**
+     * Default constructor.
+     * @param ver The proposed tag, wrapped in a Version object
+     * @param previous A list of previously released tags.
+     */
+    public PreviousReleases(final Version ver, final Releases previous) {
+        this.version = ver;
+        this.priors = previous;
+    }
+
+    /**
+     * Is this tagged release valid.
+     * @return True if the release is valid
+     */
+    public boolean isTagValid() {
+        final DefaultArtifactVersion latest = latest();
+        return new DefaultArtifactVersion(this.version.toString())
+            .compareTo(latest) == 1;
+    }
+
+    /**
+     * Returns the latest release. If there are no releases, returns "0".
+     * @return The latest release, otherwise "0" if there are no releases.
+     */
+    public DefaultArtifactVersion latest() {
+        final DefaultArtifactVersion latest;
+        final List<DefaultArtifactVersion> previous = this.transformVersions();
+        if (previous.isEmpty()) {
+            latest = new DefaultArtifactVersion("0");
+        } else {
+            latest = Collections.max(previous);
+        }
+        return latest;
+    }
+
+    /**
+     * Transforms versionsFrom Release to DefaultArtificatVersion and filters
+     * invalid version numbers. For example in these versions,
+     * ["1.0", "2.0", "3.0-b"], "3.0-b" is just ignore, therefore version "2.0"
+     * is the max.
+     * @return All prior releases wrapped in a DefaultArtifactVersion
+     */
+    private List<DefaultArtifactVersion> transformVersions() {
+        return FluentIterable
+            .from(this.priors.iterate())
+            .transform(new ReleaseToVersion())
+            .filter(new ValidVersion())
+            .toList();
+    }
+
+    private final class ValidVersion
+        implements Predicate<DefaultArtifactVersion> {
+        @Override
+        public boolean apply(final DefaultArtifactVersion ver) {
+            return new Version(ver.toString()).isValid();
+        }
+    }
+
+    private final class ReleaseToVersion
+        implements Function<Release, DefaultArtifactVersion> {
+        @Override
+        @SuppressWarnings("PMD.OnlyOneReturn")
+        public DefaultArtifactVersion apply(final Release release) {
+            final Release.Smart rel = new Release.Smart(release);
+            try {
+                final String tag = rel.tag();
+                return new DefaultArtifactVersion(tag);
+            } catch (final IOException exception) {
+                Logger.error(this, "IOException caused from rel.tag()");
+                return null;
+            }
+        }
+    }
+}

--- a/src/main/java/com/rultor/agents/github/Version.java
+++ b/src/main/java/com/rultor/agents/github/Version.java
@@ -47,7 +47,7 @@ public final class Version {
      * Version pattern.
      */
     private static final Pattern VERSION_PATTERN =
-            Pattern.compile("\\.?(?:\\d+\\.)*\\d+");
+        Pattern.compile("\\.?(?:\\d+\\.)*\\d+");
 
     /**
      * The proposed version tag.

--- a/src/main/java/com/rultor/agents/github/Version.java
+++ b/src/main/java/com/rultor/agents/github/Version.java
@@ -30,21 +30,18 @@
 package com.rultor.agents.github;
 
 import com.jcabi.aspects.Immutable;
-import java.util.Collections;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 
 /**
- * Various validations regarding version numbers.
+ * Encapsulates a release's version number.
  *
- * @author Yegor Bugayenko (yegor@teamed.io)
+ * @author Jimmy Spivey (JimDeanSpivey@gmail.com)
  * @version $Id$
  * @since 1.57
  */
 @Immutable
-public final class VersionValidator {
+public final class Version {
 
     /**
      * Version pattern.
@@ -53,27 +50,20 @@ public final class VersionValidator {
             Pattern.compile("\\.?(?:\\d+\\.)*\\d+");
 
     /**
-     * Singleton instance of Version Validator.
+     * The proposed version tag.
      */
-    private static final VersionValidator VERSION_VALIDATOR =
-            new VersionValidator();
+    private final transient String tag;
 
     /**
-     * Force clients to use factory method.
+     * Constructor with just the tag field.
+     * @param ver The version number of a release.
      */
-    private VersionValidator() {
+    public Version(final String ver) {
+        this.tag = ver;
     }
 
     /**
-     * Factory method to get an instance of VersionValidator. All operations
-     * are already thread safe.
-     * @return A singleton instance of VersionValidator
-     */
-    public static VersionValidator getInstance() {
-        return VERSION_VALIDATOR;
-    }
-
-    /**
+     * Is the version number format valid. For example:
      * Valid version numbers:
      * .1
      * 2.2
@@ -85,28 +75,19 @@ public final class VersionValidator {
      * a.b.c
      * 1.
      * 1.2.
-     * @param version Version number from a release
-     * @return True if the version is valid, false otherwise
+     * @return True if the tag is valid, false otherwise
      */
-    public boolean isVersionValid(final String version) {
-        final Matcher matcher = VERSION_PATTERN.matcher(version);
+    public boolean isValid() {
+        final Matcher matcher = VERSION_PATTERN.matcher(this.tag);
         return matcher.matches();
     }
 
     /**
-     * Is this tagged release valid.
-     * @param tag The release to be tagged
-     * @param previous The previous releases
-     * @return True if the release is valid
+     * Returns the proposed tag originally passed in the constructor.
+     * @return The proposed tag
      */
-    public boolean isReleaseValid(final String tag,
-                                  final List<DefaultArtifactVersion> previous) {
-        final DefaultArtifactVersion max;
-        if (previous.isEmpty()) {
-            max = new DefaultArtifactVersion("0");
-        } else {
-            max = Collections.max(previous);
-        }
-        return new DefaultArtifactVersion(tag).compareTo(max) == 1;
+    @Override
+    public String toString() {
+        return this.tag;
     }
 }

--- a/src/main/java/com/rultor/agents/github/VersionValidator.java
+++ b/src/main/java/com/rultor/agents/github/VersionValidator.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2009-2015, rultor.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the rultor.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.rultor.agents.github;
+
+import com.jcabi.aspects.Immutable;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+
+/**
+ * Various validations regarding version numbers.
+ *
+ * @author Yegor Bugayenko (yegor@teamed.io)
+ * @version $Id$
+ * @since 1.57
+ */
+@Immutable
+public final class VersionValidator {
+
+    /**
+     * Version pattern.
+     */
+    private static final Pattern VERSION_PATTERN =
+            Pattern.compile("\\.?(?:\\d+\\.)*\\d+");
+
+    /**
+     * Singleton instance of Version Validator.
+     */
+    private static final VersionValidator VERSION_VALIDATOR =
+            new VersionValidator();
+
+    /**
+     * Force clients to use factory method.
+     */
+    private VersionValidator() {
+    }
+
+    /**
+     * Factory method to get an instance of VersionValidator. All operations
+     * are already thread safe.
+     * @return A singleton instance of VersionValidator
+     */
+    public static VersionValidator getInstance() {
+        return VERSION_VALIDATOR;
+    }
+
+    /**
+     * Valid version numbers:
+     * .1
+     * 2.2
+     * .1.2
+     * 1.2.3.4.5.6.7
+     *
+     * Invalid version numbers:
+     * abc
+     * a.b.c
+     * 1.
+     * 1.2.
+     * @param version Version number from a release
+     * @return True if the version is valid, false otherwise
+     */
+    public boolean isVersionValid(final String version) {
+        final Matcher matcher = VERSION_PATTERN.matcher(version);
+        return matcher.matches();
+    }
+
+    /**
+     * Is this tagged release valid.
+     * @param tag The release to be tagged
+     * @param previous The previous releases
+     * @return True if the release is valid
+     */
+    public boolean isReleaseValid(final String tag,
+                                  final List<DefaultArtifactVersion> previous) {
+        final DefaultArtifactVersion max;
+        if (previous.isEmpty()) {
+            max = new DefaultArtifactVersion("0");
+        } else {
+            max = Collections.max(previous);
+        }
+        return new DefaultArtifactVersion(tag).compareTo(max) == 1;
+    }
+}

--- a/src/main/resources/phrases_en_US.properties
+++ b/src/main/resources/phrases_en_US.properties
@@ -49,7 +49,7 @@ Reports.failure=Oops, I failed. You can see the full log [here](%s) (spent %[ms]
 CommentsTag.duplicate=Release `%s` already exists! I can't duplicate it, \
     but I posted a comment there. In the future, try to avoid duplicate releases
 
-CommentsTag.version-to-low=Release `%s` version tag is too low! It must be \
+CommentsTag.version-too-low=Release `%s` version tag is too low! It must be \
     greater than the previous release `%s`.
 
 QnByArchitect.denied=Thanks for your request. @%s Please confirm this.

--- a/src/main/resources/phrases_en_US.properties
+++ b/src/main/resources/phrases_en_US.properties
@@ -49,6 +49,9 @@ Reports.failure=Oops, I failed. You can see the full log [here](%s) (spent %[ms]
 CommentsTag.duplicate=Release `%s` already exists! I can't duplicate it, \
     but I posted a comment there. In the future, try to avoid duplicate releases
 
+CommentsTag.version-to-low=Release `%s` version tag is too low! It must be \
+    greater than the previous release `%s`.
+
 QnByArchitect.denied=Thanks for your request. @%s Please confirm this.
 
 QnReferredTo.mentioned=I see you're talking about me, but I don't understand it. \

--- a/src/test/java/com/rultor/agents/github/CommentsTagTest.java
+++ b/src/test/java/com/rultor/agents/github/CommentsTagTest.java
@@ -29,6 +29,7 @@
  */
 package com.rultor.agents.github;
 
+import com.jcabi.github.Comment;
 import com.jcabi.github.Issue;
 import com.jcabi.github.Release;
 import com.jcabi.github.Releases;
@@ -89,6 +90,32 @@ public final class CommentsTagTest {
         MatcherAssert.assertThat(
             new Releases.Smart(repo.releases()).exists(tag),
             Matchers.is(true)
+        );
+    }
+
+    /**
+     * CommentsTag cannot release an older version.
+     * @throws Exception In case of error.
+     */
+    @Test
+    public void tooOldRelease() throws Exception {
+        final Repo repo = new MkGithub().randomRepo();
+        final Issue issue = repo.issues().create("", "");
+        final Agent agent = new CommentsTag(repo.github());
+        final String tag = "1.5";
+        repo.releases().create("1.0");
+        repo.releases().create("2.0");
+        repo.releases().create("3.0-b");
+        final Talk talk = CommentsTagTest.talk(issue, tag);
+        agent.execute(talk);
+        final Comment.Smart response = new Comment.Smart(
+                repo.issues().get(1).comments().get(1)
+        );
+        MatcherAssert.assertThat(
+                response.body(),
+                    Matchers.containsString(
+                            "version tag is too low"
+                    )
         );
     }
 

--- a/src/test/java/com/rultor/agents/github/CommentsTagTest.java
+++ b/src/test/java/com/rultor/agents/github/CommentsTagTest.java
@@ -109,13 +109,13 @@ public final class CommentsTagTest {
         final Talk talk = CommentsTagTest.talk(issue, tag);
         agent.execute(talk);
         final Comment.Smart response = new Comment.Smart(
-                repo.issues().get(1).comments().get(1)
+            repo.issues().get(1).comments().get(1)
         );
         MatcherAssert.assertThat(
-                response.body(),
-                    Matchers.containsString(
-                            "version tag is too low"
-                    )
+            response.body(),
+                Matchers.containsString(
+                        "version tag is too low"
+                )
         );
     }
 

--- a/src/test/java/com/rultor/agents/github/CommentsTagTest.java
+++ b/src/test/java/com/rultor/agents/github/CommentsTagTest.java
@@ -113,9 +113,9 @@ public final class CommentsTagTest {
         );
         MatcherAssert.assertThat(
             response.body(),
-                Matchers.containsString(
-                        "version tag is too low"
-                )
+            Matchers.containsString(
+                    "version tag is too low"
+            )
         );
     }
 


### PR DESCRIPTION
Validations have been added to prevent this from happening:

```
[at]rultor release tag is .1
[at]rultor release tag is .5
[at]rultor release tag is .7
[at]rultor release tag is .2
```

Rultor will not accept `.2` and instead reply with:
Release `.2` version tag is too low! It must be greater than the previous release `.7`.