### PR TITLE
README should have what problems Rultor solves

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ Additionally, because of the way Rultor integrates with modern issue trackers,
 all the logs are stored and published to the ticket on which Rultor was
 mentioned. Making vital information easily accessible to all developers.
 
+Rultor performs pre-flight builds. Instead of merging into master and then
+seeing if your changes broke the build or not, Rultor checks out the master
+branch, apply your changes to it, then runs everything it was set up to run.
+If, and only if, everything goes well, Rultor merges the changes into master.
+This programmatically prevents the master from being broken by developers. Not
+having to worry about breaking the build for everyone else has a very positive
+impact in the way developers write code, increasing their productivity and
+mitigating their fear of making mistakes.
+
 Lastly, Rultor provides an integrated and humanized interface to DevOps tools,
 as a human-readable sentence suffices to trigger a merge or a release.
 

--- a/README.md
+++ b/README.md
@@ -26,17 +26,17 @@ TBD... _product statement_
 
 ## What Problems Does Rultor Solve?
 
-Automated build scripts have been around for some time. Rultor attempts to
+Automated deployment scripts have been around for some time. Rultor attempts to
 tackle the problems those scripts do not.
 
 The first benefit of Rultor is that it gives you isolation of your deployment
-script in its own virtual environment by using Docker containers.  This
+script in its own virtual environment by using Docker containers. This
 substantially reduces the amount of external state that could affect your build
 and makes errors more easily reproducible.
 
 Additionally, because of the way Rultor integrates with modern issue trackers,
-all the logs are stored in the meaningful ticket. Making vital information
-easily accessible to all developers.
+all the logs are stored and published to the ticket on which Rultor was
+mentioned. Making vital information easily accessible to all developers.
 
 Lastly, Rultor provides an integrated and humanized interface to DevOps tools,
 as a human-readable sentence suffices to trigger a merge or a release.

--- a/README.md
+++ b/README.md
@@ -24,9 +24,22 @@ Default Docker image is [yegor256/rultor](https://registry.hub.docker.com/u/yego
 
 TBD... _product statement_
 
-## What Problem Does Rultor Solve?
+## What Problems Does Rultor Solve?
 
-TBD... _stakeholders and needs_
+Automated build scripts have been around for some time. Rultor attempts to
+tackle the problems those scripts do not.
+
+The first benefit of Rultor is that it gives you isolation of your deployment
+script in its own virtual environment by using Docker containers.  This
+substantially reduces the amount of external state that could affect your build
+and makes errors more easily reproducible.
+
+Additionally, because of the way Rultor integrates with modern issue trackers,
+all the logs are stored in the meaningful ticket. Making vital information
+easily accessible to all developers.
+
+Lastly, Rultor provides an integrated and humanized interface to DevOps tools,
+as a human-readable sentence suffices to trigger a merge or a release.
 
 ## How Rultor Works?
 


### PR DESCRIPTION
Closes #997

Also pluralized "Problem" as Rultor solves more than a single problem.
Wrote paragraphs instead of an enumeration so that the README looks more
like thorough documentation and less like a TODO list.