### PR TITLE
fixing site target by running jekyll in bundle context, see #1001

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -917,14 +917,29 @@
                         <inherited>false</inherited>
                         <executions>
                             <execution>
+                                <id>bundle install</id>
+                                <phase>pre-site</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>bundle</executable>
+                                    <arguments>
+                                        <argument>install</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
                                 <id>jekyll-build</id>
                                 <phase>pre-site</phase>
                                 <goals>
                                     <goal>exec</goal>
                                 </goals>
                                 <configuration>
-                                    <executable>jekyll</executable>
+                                    <executable>bundle</executable>
                                     <arguments>
+                                        <argument>exec</argument>
+                                        <argument>jekyll</argument>
                                         <argument>build</argument>
                                         <argument>--source</argument>
                                         <argument>${basedir}/src/jekyll</argument>


### PR DESCRIPTION
This PR addresses Issue #1001 reproduced and then tested via:
```
docker run -it -v "${PWD}:${PWD}" --rm -w "${PWD}" yegor256/rultor /bin/bash -lc 'mvn clean site -Pjekyll'
```

### Deployments Started Failing because:

From what I can see the problem was caused by  ba0d145eb, which added the est gem before running bundler. 
est according to https://rubygems.org/gems/est/versions/0.3.1 requires a specific Nokogiri version ( 1.6.6.4).
The current Gemfile though installs nokogiri (1.6.7.2) causing a conflict shown in https://github.com/yegor256/rultor/issues/994#issuecomment-179522451 and breaking est initially.

This conflict was then resolved in 8eaf7e2 by installing not in the system scope, now making est load fine from the system gems. The system gem context though does not load jekyll-sass now, since bundler was not run in the sudo context as per 8eaf7e2.

Also c08600fb then set the Jekyll version to 2.4.0 as per the bundle. The currently available Docker Image rev. 43b7ceed592c though shows Jekyll 3.1.1 install in the system context coming Jekyll being install in the Dockerfile currently:
https://github.com/yegor256/rultor/blob/master/src/docker/Dockerfile#L106
```
RUN git clone https://github.com/yegor256/rultor.git && \
  cd rultor && \
  gem install jekyll && \
  mvn clean install -Pqulice --quiet && \
  cd .. && \
  rm -rf rultor
```

Hence running outside the bundle context will cause the wrong Jekyll version to be used even if it were to not conflict with est.

### Fixed by:
This situation can be fixed by simply running Jekyll in the context of the bundle and hence not having to deal with the system nokogiri version required by est.

This is what the second command added to the pre-site execution does. In order to make the build one off in this spot I also added the bundle install to this build step.


 


