### PR TITLE
#946 Updated outdated dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ sending us your pull request please run full Maven build:
 $ mvn clean install -Pqulice
 ```
 
-To avoid build errors use maven 3.2+
+To avoid build errors use maven 3.2.5+
 
 ## Got questions?
 

--- a/pom.xml
+++ b/pom.xml
@@ -96,33 +96,33 @@
         <dependency>
             <groupId>org.takes</groupId>
             <artifactId>takes</artifactId>
-            <version>0.29</version>
+            <version>0.31.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
-            <version>1.10.44</version>
+            <version>1.10.51</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.10.44</version>
+            <version>1.10.51</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-ec2</artifactId>
-            <version>1.10.44</version>
+            <version>1.10.51</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-dynamodb</artifactId>
-            <version>1.10.44</version>
+            <version>1.10.51</version>
         </dependency>
         <dependency>
             <groupId>com.jcabi.incubator</groupId>
             <artifactId>xembly</artifactId>
-            <version>0.21.4</version>
+            <version>0.22</version>
         </dependency>
         <dependency>
             <groupId>org.twitter4j</groupId>
@@ -219,7 +219,7 @@
         <dependency>
             <groupId>com.jcabi</groupId>
             <artifactId>jcabi-xml</artifactId>
-            <version>0.17</version>
+            <version>0.17.2</version>
         </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>
@@ -272,7 +272,7 @@
         <dependency>
             <groupId>com.jcabi</groupId>
             <artifactId>jcabi-github</artifactId>
-            <version>0.25</version>
+            <version>0.26</version>
         </dependency>
         <dependency>
             <groupId>com.jcabi</groupId>
@@ -340,7 +340,7 @@
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>xmlgraphics-commons</artifactId>
-            <version>2.0.1</version>
+            <version>2.1</version>
             <scope>runtime</scope>
         </dependency>
     </dependencies>
@@ -413,7 +413,7 @@
             <plugin>
                 <groupId>nl.geodienstencentrum.maven</groupId>
                 <artifactId>sass-maven-plugin</artifactId>
-                <version>2.14</version>
+                <version>2.15</version>
                 <executions>
                     <execution>
                         <id>generate-css</id>

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -93,20 +93,8 @@ RUN mkdir jsl && \
   rm -rf jsl
 # RUN pecl install xdebug-beta && \
 #   echo "zend_extension=xdebug.so" > /etc/php5/cli/conf.d/xdebug.ini
-
 # Java
 RUN apt-get install -y default-jdk
-RUN apt-get install -y gdebi && \
-  wget --quiet http://ppa.launchpad.net/natecarlson/maven3/ubuntu/pool/main/m/maven3/maven3_3.2.1-0~ppa1_all.deb && \
-  gdebi --non-interactive maven3_3.2.1-0~ppa1_all.deb && \
-  ln -s /usr/share/maven3/bin/mvn /usr/bin/mvn && \
-  rm -rf maven3_3.2.1-0~ppa1_all.deb
-RUN git clone https://github.com/yegor256/rultor.git && \
-  cd rultor && \
-  gem install jekyll && \
-  mvn clean install -Pqulice --quiet && \
-  cd .. && \
-  rm -rf rultor
 
 # LaTeX
 RUN apt-get install -y texlive-latex-extra
@@ -125,6 +113,27 @@ RUN apt-get install -y s3cmd
 RUN apt-get install -y nodejs npm
 RUN sudo npm install -g npm
 RUN ln -s /usr/bin/nodejs /usr/bin/node
+
+# Maven
+ENV MAVEN_VERSION 3.3.3
+ENV M2_HOME "/usr/local/apache-maven/apache-maven-${MAVEN_VERSION}"
+RUN wget --quiet "http://ftp.wayne.edu/apache/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" && \
+  mkdir -p /usr/local/apache-maven && \
+  mv "apache-maven-${MAVEN_VERSION}-bin.tar.gz" /usr/local/apache-maven && \
+  tar xzvf "/usr/local/apache-maven/apache-maven-${MAVEN_VERSION}-bin.tar.gz" -C /usr/local/apache-maven/ && \
+  update-alternatives --install /usr/bin/mvn mvn "${M2_HOME}/bin/mvn" 1 && \
+  update-alternatives --config mvn
+
+RUN gem install jekyll
+
+ENV MAVEN_OPTS "-Xms512m -Xmx2g"
+ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
+COPY settings.xml /root/.m2/settings.xml
+RUN git clone https://github.com/yegor256/rultor.git --depth=1
+RUN cd rultor && \
+  mvn clean install -Pqulice && \
+  cd .. && \
+  rm -rf rultor
 
 # One more time, right before the end
 RUN apt-get update -y

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -115,9 +115,9 @@ RUN sudo npm install -g npm
 RUN ln -s /usr/bin/nodejs /usr/bin/node
 
 # Maven
-ENV MAVEN_VERSION 3.3.3
+ENV MAVEN_VERSION 3.3.9
 ENV M2_HOME "/usr/local/apache-maven/apache-maven-${MAVEN_VERSION}"
-RUN wget --quiet "http://ftp.wayne.edu/apache/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" && \
+RUN wget --quiet "http://mirror.dkd.de/apache/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" && \
   mkdir -p /usr/local/apache-maven && \
   mv "apache-maven-${MAVEN_VERSION}-bin.tar.gz" /usr/local/apache-maven && \
   tar xzvf "/usr/local/apache-maven/apache-maven-${MAVEN_VERSION}-bin.tar.gz" -C /usr/local/apache-maven/ && \

--- a/src/docker/settings.xml
+++ b/src/docker/settings.xml
@@ -1,0 +1,10 @@
+<settings>
+    <mirrors>
+        <mirror>
+            <id>Maven</id>
+            <name>Maven Central</name>
+            <url>http://repo.maven.apache.org/maven2</url>
+            <mirrorOf>*</mirrorOf>
+        </mirror>
+    </mirrors>
+</settings>


### PR DESCRIPTION
This resolves #946.

Versioneye shows 10 dependencies as outdated here: https://www.versioneye.com/user/projects/561a9d87a193340f28000fd3

* Updated those 10 in this PR.
* Updated Dockerfile to use Maven 3.3.3, since the newer plugins required more recent Maven than 3.2.1. 3.3.3 was the most recent I could make build on Ubuntu 14.04.
* Updated Readme accordingly, regarding the minimum Maven version.
