### PR TITLE
Removed --privileged Flag from Docker Container Run

### DIFF
--- a/src/main/resources/com/rultor/agents/req/_head.sh
+++ b/src/main/resources/com/rultor/agents/req/_head.sh
@@ -93,7 +93,6 @@ function docker_when_possible {
     docker rm -f "${container}"
   fi
   docker run --rm -v "$(pwd):/main" "${vars[@]}" \
-    --privileged=true \
     --hostname=docker \
     --memory=6g --memory-swap=16g --oom-kill-disable \
     "--cidfile=$(pwd)/cid" -w=/main \


### PR DESCRIPTION
This removes the use of the ```--privileged```  flag from the script starting the Docker run.

# Reason
The privileged flag creates a significant security issue for Rultor as it causes the host machine's devices to be fully accessible to the container run.
An attacker could take advantage of this fact and provide an image/script combination to Rultor that mounts the host's hard drive(s) (now available as a standard /dev/... ) into the container.  
Combined with the fact that the Docker daemon does run under the root user, an attacker can trivially gain full control of the host via a privileged container.
