### PR TITLE
#884 convert non-utf8 chars to utf8 when tailing Rultor output

### DIFF
--- a/src/main/java/com/rultor/agents/daemons/Tail.java
+++ b/src/main/java/com/rultor/agents/daemons/Tail.java
@@ -235,10 +235,17 @@ public final class Tail {
             final Shell shell = new TalkShells(this.xml).get();
             final ByteArrayOutputStream baos = new ByteArrayOutputStream();
             shell.exec(
-                String.format(
-                    // @checkstyle LineLength (1 line)
-                    "dir=%s; (cat \"${dir}/stdout\" 2>/dev/null || echo \"file $file is gone\") | col -b",
-                    SSH.escape(this.xml.xpath("/talk/daemon/dir/text()").get(0))
+                StringUtils.join(
+                    String.format(
+                        "dir=%s;",
+                        SSH.escape(
+                            this.xml.xpath("/talk/daemon/dir/text()").get(0)
+                        )
+                    ),
+                    " (cat \"${dir}/stdout\" 2>/dev/null",
+                    " || echo \"file $file is gone\")",
+                    " | iconv -f utf-8 -t utf-8 -c",
+                    " | LANG=en_US.UTF-8 col -b"
                 ),
                 new NullInputStream(0L), baos,
                 Logger.stream(Level.SEVERE, true)

--- a/src/test/java/com/rultor/agents/daemons/TailITCase.java
+++ b/src/test/java/com/rultor/agents/daemons/TailITCase.java
@@ -53,11 +53,6 @@ import org.xembly.Directives;
 public final class TailITCase {
 
     /**
-     * Attribute key for the id of a talk directive.
-     */
-    private static final String DIRECTIVE_ID_KEY = "id";
-
-    /**
      * Temp directory.
      * @checkstyle VisibilityModifierCheck (5 lines)
      */
@@ -80,26 +75,29 @@ public final class TailITCase {
         );
         final Talk talk = new Talk.InFile();
         final String hash = "a1b5c3e3";
+        final String key = "id";
         talk.modify(
             new Directives().xpath("/talk")
                 .add("daemon")
-                .attr(TailITCase.DIRECTIVE_ID_KEY, hash)
+                .attr(key, hash)
                 .add("title").set("tail").up()
                 .add("script").set("empty").up()
                 .add("dir").set(home.getAbsolutePath()).up()
                 .add("code").set("-7").up()
                 .add("started").set(new Time().iso()).up()
                 .add("ended").set(new Time().iso()).up().up()
-                .add("shell").attr(TailITCase.DIRECTIVE_ID_KEY, hash)
+                .add("shell").attr(key, hash)
                 .add("host").set("localhost").up()
                 .add("port").set(Integer.toString(sshd.port())).up()
                 .add("login").set(sshd.login()).up()
                 .add("key").set(sshd.key()).up().up()
         );
-        final Tail agent = new Tail(talk.read(), hash);
         MatcherAssert.assertThat(
-            IOUtils.toString(agent.read(), Charsets.UTF_8),
-            Matchers.equalTo(String.format("%sê\n", clean))
+            IOUtils.toString(
+                new Tail(talk.read(), hash).read(),
+                Charsets.UTF_8
+            ),
+            Matchers.is(String.format("%sê\n", clean))
         );
     }
 

--- a/src/test/java/com/rultor/agents/daemons/TailITCase.java
+++ b/src/test/java/com/rultor/agents/daemons/TailITCase.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2009-2015, rultor.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the rultor.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.rultor.agents.daemons;
+
+import com.google.common.base.Charsets;
+import com.jcabi.ssh.SSHD;
+import com.rultor.Time;
+import com.rultor.spi.Talk;
+import java.io.File;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.xembly.Directives;
+
+/**
+ * Tests for ${@link Tail}.
+ *
+ * @author Armin Braun (me@obrown.io)
+ * @version $Id$
+ * @since 1.62
+ */
+public final class TailITCase {
+
+    /**
+     * Attribute key for the id of a talk directive.
+     */
+    private static final String DIRECTIVE_ID_KEY = "id";
+
+    /**
+     * Temp directory.
+     * @checkstyle VisibilityModifierCheck (5 lines)
+     */
+    @Rule
+    public final transient TemporaryFolder temp = new TemporaryFolder();
+
+    /**
+     * Tail can convert non UTF-8 chars in StdOut to UTF-8.
+     * @throws Exception In case of error.
+     */
+    @Test
+    public void tailsNonUtf() throws Exception {
+        final SSHD sshd = new SSHD(this.temp.newFolder());
+        final File home = new File(sshd.home(), "testTail");
+        FileUtils.forceMkdir(home);
+        final String clean = "some output";
+        FileUtils.write(
+            new File(home, "stdout"),
+            String.format("%s\u00ea", clean)
+        );
+        final Talk talk = new Talk.InFile();
+        final String hash = "a1b5c3e3";
+        talk.modify(
+            new Directives().xpath("/talk")
+                .add("daemon")
+                .attr(TailITCase.DIRECTIVE_ID_KEY, hash)
+                .add("title").set("tail").up()
+                .add("script").set("empty").up()
+                .add("dir").set(home.getAbsolutePath()).up()
+                .add("code").set("-7").up()
+                .add("started").set(new Time().iso()).up()
+                .add("ended").set(new Time().iso()).up().up()
+                .add("shell").attr(TailITCase.DIRECTIVE_ID_KEY, hash)
+                .add("host").set("localhost").up()
+                .add("port").set(Integer.toString(sshd.port())).up()
+                .add("login").set(sshd.login()).up()
+                .add("key").set(sshd.key()).up().up()
+        );
+        final Tail agent = new Tail(talk.read(), hash);
+        MatcherAssert.assertThat(
+            IOUtils.toString(agent.read(), Charsets.UTF_8),
+            Matchers.equalTo(String.format("%sê\n", clean))
+        );
+    }
+
+}


### PR DESCRIPTION
#884 is resolved by this:

* Added iconv filter on the tailing output
 * Fixed the style breaking, no need to make this line longer :)
* Added unittest testing the correct conversion of  `"\u00ea"` to `"ê"`