### PR TITLE
#901 make rultor run docker container in in tty mode

### DIFF
--- a/src/main/resources/com/rultor/agents/req/_head.sh
+++ b/src/main/resources/com/rultor/agents/req/_head.sh
@@ -92,7 +92,7 @@ function docker_when_possible {
   if docker ps --filter=status=exited | grep --quiet "\s${container}\s*\$"; then
     docker rm -f "${container}"
   fi
-  docker run --rm -v "$(pwd):/main" "${vars[@]}" \
+  docker run -t --rm -v "$(pwd):/main" "${vars[@]}" \
     --hostname=docker \
     --memory=6g --memory-swap=16g --oom-kill-disable \
     "--cidfile=$(pwd)/cid" -w=/main \

--- a/src/test/java/com/rultor/agents/req/StartsRequestTest.java
+++ b/src/test/java/com/rultor/agents/req/StartsRequestTest.java
@@ -152,9 +152,10 @@ public final class StartsRequestTest {
                     .with(Matchers.containsString("docker_when_possible\n"))
                     .with(Matchers.containsString("load average is "))
                     .with(Matchers.containsString("low enough to run a"))
+                    .with(Matchers.containsString("DOCKER-2: -t"))
                     .with(
                         Matchers.containsString(
-                            "DOCKER-5: --env=MAVEN_OPTS=-Xmx2g -Xms1g"
+                            "DOCKER-6: --env=MAVEN_OPTS=-Xmx2g -Xms1g"
                         )
                     )
                     .with(Matchers.containsString("useradd"))


### PR DESCRIPTION
#901 is solved by this.

* Make Docker container run using pseudo tty 
* Adjust unit-test slightly to account for added -t flag

This is hard to test in a 100% portable manner since it depends on the Docker host machine Rultor connects to via ssh, should work fine on any standard Linux system though. It's just that the Docker output is piped to a file that is then tailed on the host, given that this only involves stdOut from Docker we should be fine here though.

Difference is obvious :)
![image](https://cloud.githubusercontent.com/assets/6490959/13273127/777b9ffa-daa1-11e5-91d1-a2ea3b1ab25f.png)


