### PR TITLE
#982 Architects are commanders for all commands now

### DIFF
--- a/src/main/java/com/rultor/agents/github/qtn/QnAskedBy.java
+++ b/src/main/java/com/rultor/agents/github/qtn/QnAskedBy.java
@@ -157,10 +157,11 @@ public final class QnAskedBy implements Question {
      * @throws IOException If fails
      */
     private Collection<String> commanders(final Repo repo) throws IOException {
-        final Collection<String> logins = new LinkedList<String>();
+        final Collection<String> logins = new LinkedList<>();
         final XML xml = this.profile.read();
         logins.addAll(new Crew(repo).names());
         logins.addAll(xml.xpath(this.xpath));
+        logins.addAll(xml.xpath("/p/entry[@key='architect']/text()"));
         return logins;
     }
 


### PR DESCRIPTION
#982 is resolved by this.

*  Read architects the same way repo collaborators are read as commanders.
*  Test added for the case of the deploy command as broken in #982 