### PR TITLE
#946 Heroku does not automatically upgrade maven, we need to specify this manually

### DIFF
--- a/system.properties
+++ b/system.properties
@@ -1,1 +1,2 @@
 java.runtime.version=1.7
+maven.version=3.3.9


### PR DESCRIPTION
#946 needs this, we forgot about this part.

See [here](https://devcenter.heroku.com/articles/java-support#specifying-a-maven-version) -> Heroku does not automatically upgrade Maven.