### PR TITLE
#982, fixed xpath for xml representation of architects in yaml when answering questions

### DIFF
--- a/src/main/java/com/rultor/agents/github/qtn/QnAskedBy.java
+++ b/src/main/java/com/rultor/agents/github/qtn/QnAskedBy.java
@@ -161,7 +161,7 @@ public final class QnAskedBy implements Question {
         final XML xml = this.profile.read();
         logins.addAll(new Crew(repo).names());
         logins.addAll(xml.xpath(this.xpath));
-        logins.addAll(xml.xpath("/p/entry[@key='architect']/text()"));
+        logins.addAll(xml.xpath("/p/entry[@key='architect']/item/text()"));
         return logins;
     }
 

--- a/src/test/java/com/rultor/agents/github/qtn/QnAskedByTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnAskedByTest.java
@@ -37,6 +37,7 @@ import com.jcabi.xml.XMLDocument;
 import com.rultor.agents.github.Question;
 import com.rultor.spi.Profile;
 import java.net.URI;
+import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -100,7 +101,10 @@ public final class QnAskedByTest {
             new Profile.Fixed(
                 new XMLDocument(
                     String.format(
-                        "<p><entry key='architect'>%s</entry></p>",
+                        StringUtils.join(
+                            "<p><entry key='architect'><item>%s</item>",
+                            "<item>fooo</item></entry></p>"
+                        ),
                         repo.github().users().self().login()
                     )
                 )

--- a/src/test/java/com/rultor/profiles/GithubProfileTest.java
+++ b/src/test/java/com/rultor/profiles/GithubProfileTest.java
@@ -65,6 +65,9 @@ public final class GithubProfileTest {
                 "assets:",
                 "  test.xml: jeff/test1#test.xml",
                 "  beta: jeff/test1#test.xml",
+                "architect:",
+                " - jeff",
+                " - donald",
                 "merge:",
                 "  script: hello!"
             )
@@ -88,6 +91,10 @@ public final class GithubProfileTest {
                 "/p/entry[@key='assets']/entry[@key='test.xml']",
                 "/p/entry[@key='assets']/entry[@key='beta']"
             )
+        );
+        MatcherAssert.assertThat(
+            profile.read().xpath("/p/entry[@key='architect']/item/text()"),
+            Matchers.contains("jeff", "donald")
         );
         MatcherAssert.assertThat(
             profile.assets(),


### PR DESCRIPTION
#982 is fixed by this.

This is a very trivial correction of the first PR for this containing:
* corrected xpath to architects
 * initial fix missed that those are a list :(, now fixed in test and production code
* also added test to yaml reading describing this fact.