### PR TITLE
#960 prevent outdated versions from being released.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,6 +343,11 @@
             <version>2.1</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>3.3.9</version>
+        </dependency>
     </dependencies>
     <build>
         <pluginManagement>

--- a/src/main/java/com/rultor/agents/github/qtn/QnRelease.java
+++ b/src/main/java/com/rultor/agents/github/qtn/QnRelease.java
@@ -60,8 +60,7 @@ public final class QnRelease implements Question {
     /**
      * Pattern matching the version tag of the release enclosed by backticks.
      */
-    private static final  Pattern QUESTION_PATTERN =
-        Pattern.compile("`(.+)`");
+    private static final Pattern QUESTION_PATTERN = Pattern.compile("`(.+)`");
 
     /**
      * Message bundle.
@@ -84,25 +83,7 @@ public final class QnRelease implements Question {
             final String name = matcher.group(1);
             final ReleaseTag release = new ReleaseTag(issue.repo(), name);
             if (release.allowed()) {
-                new Answer(comment).post(
-                    true,
-                    String.format(
-                        QnRelease.PHRASES.getString("QnRelease.start"),
-                        home.toASCIIString()
-                    )
-                );
-                req = new Req.Simple(
-                    "release",
-                    new ImmutableMap.Builder<String, String>()
-                        .put("head_branch", "master")
-                        .put(
-                            "head",
-                            String.format(
-                                "git@github.com:%s.git",
-                                comment.issue().repo().coordinates()
-                            )
-                        ).build()
-                );
+                req = QnRelease.affirmative(comment, home);
             } else {
                 new Answer(comment).post(
                     false,
@@ -115,13 +96,39 @@ public final class QnRelease implements Question {
                 req = Req.EMPTY;
             }
         } else {
-            new Answer(comment).post(
-                false,
-                QnRelease.PHRASES.getString("QnRelease.missing-tag")
-            );
-            req = Req.EMPTY;
+            req = QnRelease.affirmative(comment, home);
         }
         return req;
+    }
+
+    /**
+     * Confirms that Rultor is starting the release process.
+     * @param comment Comment that triggered the release
+     * @param home URI of the release tail
+     * @return Req.Simple containing the release parameters
+     * @throws IOException on error
+     */
+    private static Req affirmative(final Comment.Smart comment,
+        final URI home) throws IOException {
+        new Answer(comment).post(
+            true,
+            String.format(
+                QnRelease.PHRASES.getString("QnRelease.start"),
+                home.toASCIIString()
+            )
+        );
+        return new Req.Simple(
+            "release",
+            new ImmutableMap.Builder<String, String>()
+                .put("head_branch", "master")
+                .put(
+                    "head",
+                    String.format(
+                        "git@github.com:%s.git",
+                        comment.issue().repo().coordinates()
+                    )
+                ).build()
+        );
     }
 
 }

--- a/src/main/java/com/rultor/agents/github/qtn/QnRelease.java
+++ b/src/main/java/com/rultor/agents/github/qtn/QnRelease.java
@@ -77,7 +77,7 @@ public final class QnRelease implements Question {
         if (matcher.matches()) {
             final String name = matcher.group(1);
             final ReleaseTag release = new ReleaseTag(issue.repo(), name);
-            if (release.release()) {
+            if (release.allowed()) {
                 new Answer(comment).post(
                     true,
                     String.format(

--- a/src/main/java/com/rultor/agents/github/qtn/QnRelease.java
+++ b/src/main/java/com/rultor/agents/github/qtn/QnRelease.java
@@ -58,6 +58,12 @@ import lombok.ToString;
 public final class QnRelease implements Question {
 
     /**
+     * Pattern matching the version tag of the release enclosed by backticks.
+     */
+    private static final  Pattern QUESTION_PATTERN =
+        Pattern.compile("`(.+)`");
+
+    /**
      * Message bundle.
      */
     private static final ResourceBundle PHRASES =
@@ -72,9 +78,9 @@ public final class QnRelease implements Question {
             issue.repo().coordinates(), issue.number(), comment.number()
         );
         final Req req;
-        final Matcher matcher = Pattern.compile(".*release.*`(.+)`.*")
+        final Matcher matcher = QnRelease.QUESTION_PATTERN
             .matcher(comment.body());
-        if (matcher.matches()) {
+        if (matcher.find()) {
             final String name = matcher.group(1);
             final ReleaseTag release = new ReleaseTag(issue.repo(), name);
             if (release.allowed()) {

--- a/src/main/java/com/rultor/agents/github/qtn/ReleaseTag.java
+++ b/src/main/java/com/rultor/agents/github/qtn/ReleaseTag.java
@@ -48,7 +48,8 @@ import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 final class ReleaseTag {
 
     /**
-     * Pattern matching semantically valid versions.
+     * Pattern matching semantically valid versions, that also only consist in
+     * digits and dots.
      */
     private static final Pattern VERSION_PATTERN =
         Pattern.compile("^(\\d+\\.)*(\\d+)$");
@@ -77,8 +78,8 @@ final class ReleaseTag {
      * Checks if this tag can be released.
      * A tag can be released if it is either not named as a semantically
      * correct version or has a higher version number than all existing tags.
-     * @return Boolean
-     * @throws IOException on error.
+     * @return True if this tag can be released
+     * @throws IOException on error
      */
     public boolean allowed() throws IOException {
         return !ReleaseTag.valid(this.name)
@@ -87,8 +88,8 @@ final class ReleaseTag {
 
     /**
      * Returns the tag name of the highest version from the repo.
-     * @return String name of the highest released version.
-     * @throws IOException on error.
+     * @return String name of the highest released version
+     * @throws IOException on error
      */
     public String reference() throws IOException {
         String tag = "0";
@@ -107,7 +108,7 @@ final class ReleaseTag {
      * Checks that a tag is newer than a given reference.
      * @param reference String
      * @param tag String
-     * @return Boolean true if tag is new than reference.
+     * @return True if tag is newer than reference
      */
     private static boolean newer(final String reference, final String tag) {
         return new DefaultArtifactVersion(reference).compareTo(
@@ -116,9 +117,10 @@ final class ReleaseTag {
     }
 
     /**
-     * Checks tag string format being a valid release version.
-     * @param identifier String tag name.
-     * @return Boolean
+     * Checks that tag is a valid release version, consisting only in digits
+     * and dots.
+     * @param identifier String tag name
+     * @return True if identifier is a valid release version
      */
     private static boolean valid(final String identifier) {
         return ReleaseTag.VERSION_PATTERN.matcher(identifier).matches();

--- a/src/main/java/com/rultor/agents/github/qtn/ReleaseTag.java
+++ b/src/main/java/com/rultor/agents/github/qtn/ReleaseTag.java
@@ -48,7 +48,7 @@ import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 final class ReleaseTag {
 
     /**
-     * Pattern matching semantically valid versions, that also only consist in
+     * Pattern to match semantically valid versions, that consist only of
      * digits and dots.
      */
     private static final Pattern VERSION_PATTERN =

--- a/src/main/java/com/rultor/agents/github/qtn/ReleaseTag.java
+++ b/src/main/java/com/rultor/agents/github/qtn/ReleaseTag.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2009-2015, rultor.com
+ * Copyright (c) 2009-2016, rultor.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/main/java/com/rultor/agents/github/qtn/ReleaseTag.java
+++ b/src/main/java/com/rultor/agents/github/qtn/ReleaseTag.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2009-2015, rultor.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the rultor.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.rultor.agents.github.qtn;
+
+import com.jcabi.aspects.Immutable;
+import com.jcabi.github.Release;
+import com.jcabi.github.Repo;
+import com.jcabi.github.Smarts;
+import java.io.IOException;
+import java.util.regex.Pattern;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+
+/**
+ * Release Tag validator, ensures not releasing already outdated tags.
+ *
+ * @author Armin Braun (me@obrown.io)
+ * @version $Id$
+ * @since 1.62
+ */
+@Immutable
+final class ReleaseTag {
+
+    /**
+     * Pattern matching semantically valid versions.
+     */
+    private static final Pattern VERSION_PATTERN =
+        Pattern.compile("^(\\d+\\.)*(\\d+)$");
+
+    /**
+     * Github.
+     */
+    private final transient Repo repo;
+
+    /**
+     * Tag-name of the release.
+     */
+    private final transient String name;
+
+    /**
+     * Ctor.
+     * @param rpo Github repo
+     * @param version String release tag name
+     */
+    ReleaseTag(final Repo rpo, final String version) {
+        this.repo = rpo;
+        this.name = version;
+    }
+
+    /**
+     * Checks if this tag can be released.
+     * A tag can be released if it is either not named as a semantically
+     * correct version or has a higher version number than all existing tags.
+     * @return Boolean
+     * @throws IOException on error.
+     */
+    public boolean release() throws IOException {
+        return !ReleaseTag.valid(this.name)
+            || ReleaseTag.newer(this.reference(), this.name);
+    }
+
+    /**
+     * Returns the tag name of the highest version from the repo.
+     * @return String name of the highest released version.
+     * @throws IOException on error.
+     */
+    public String reference() throws IOException {
+        String tag = "0";
+        final Iterable<Release.Smart> rels =
+            new Smarts<>(this.repo.releases().iterate());
+        for (final Release.Smart rel : rels) {
+            final String version = rel.tag();
+            if (ReleaseTag.valid(version) && ReleaseTag.newer(tag, version)) {
+                tag = version;
+            }
+        }
+        return tag;
+    }
+
+    /**
+     * Checks that a tag is newer than a given reference.
+     * @param reference String
+     * @param tag String
+     * @return Boolean true if tag is new than reference.
+     */
+    private static boolean newer(final String reference, final String tag) {
+        return new DefaultArtifactVersion(reference).compareTo(
+            new DefaultArtifactVersion(tag)
+        ) < 0;
+    }
+
+    /**
+     * Checks tag string format being a valid release version.
+     * @param identifier String tag name.
+     * @return Boolean
+     */
+    private static boolean valid(final String identifier) {
+        return ReleaseTag.VERSION_PATTERN.matcher(identifier).matches();
+    }
+
+}

--- a/src/main/java/com/rultor/agents/github/qtn/ReleaseTag.java
+++ b/src/main/java/com/rultor/agents/github/qtn/ReleaseTag.java
@@ -80,7 +80,7 @@ final class ReleaseTag {
      * @return Boolean
      * @throws IOException on error.
      */
-    public boolean release() throws IOException {
+    public boolean allowed() throws IOException {
         return !ReleaseTag.valid(this.name)
             || ReleaseTag.newer(this.reference(), this.name);
     }

--- a/src/main/resources/phrases_en_US.properties
+++ b/src/main/resources/phrases_en_US.properties
@@ -36,7 +36,12 @@ QnMerge.base-is-gone=Base repository is gone, can't merge into it
 QnDeploy.start=OK, I'll try to deploy now. You can check the progress [here](%s)
 
 QnRelease.start=OK, I will release it now. Please check the progress [here](%s)
-
+QnRelease.missing-tag=No release tag specified, please provide a release version.\n \
+                      More information on the release command can be found \
+                      [here](http://doc.rultor.com/basics.html).
+QnRelease.invalid-tag=Invalid release tag `%s` specified. There is already a \
+                      release `%s` newer than the given release in this \
+                      repository.
 QnStop.stop=OK, I'll try to stop current task.
 
 QnAskedBy.denied=Sorry, I accept such requests only from authorized commanders: %s \

--- a/src/main/resources/phrases_en_US.properties
+++ b/src/main/resources/phrases_en_US.properties
@@ -36,9 +36,6 @@ QnMerge.base-is-gone=Base repository is gone, can't merge into it
 QnDeploy.start=OK, I'll try to deploy now. You can check the progress [here](%s)
 
 QnRelease.start=OK, I will release it now. Please check the progress [here](%s)
-QnRelease.missing-tag=No release tag specified, please provide a release version.\n \
-                      More information on the release command can be found \
-                      [here](http://doc.rultor.com/basics.html).
 QnRelease.invalid-tag=Invalid release tag `%s` specified. There is already a \
                       release `%s` newer than the given release in this \
                       repository.

--- a/src/test/java/com/rultor/agents/github/qtn/QnReleaseTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnReleaseTest.java
@@ -55,7 +55,7 @@ public final class QnReleaseTest {
 
     /**
      * QnRelease can build a request.
-     * @throws Exception In case of error.
+     * @throws Exception In case of error
      */
     @Test
     public void buildsRequest() throws Exception {
@@ -81,7 +81,7 @@ public final class QnReleaseTest {
 
     /**
      * QnRelease can deny release when tag is outdated.
-     * @throws Exception In case of error.
+     * @throws Exception In case of error
      */
     @Test
     public void denyOutdatedTag() throws Exception {
@@ -99,12 +99,11 @@ public final class QnReleaseTest {
             new Comment.Smart(issue.comments().get(2)).body(),
             Matchers.containsString("There is already a release `1.7`")
         );
-        issue.comments().post("release");
     }
 
     /**
      * QnRelease can deny release when tag name is not given.
-     * @throws Exception In case of error.
+     * @throws Exception In case of error
      */
     @Test
     public void denyMissingTag() throws Exception {

--- a/src/test/java/com/rultor/agents/github/qtn/ReleaseTagTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/ReleaseTagTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2009-2015, rultor.com
+ * Copyright (c) 2009-2016, rultor.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/test/java/com/rultor/agents/github/qtn/ReleaseTagTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/ReleaseTagTest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2009-2015, rultor.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the rultor.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.rultor.agents.github.qtn;
+
+import com.jcabi.github.Repo;
+import com.jcabi.github.mock.MkGithub;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Tests for ${@link ReleaseTag}.
+ *
+ * @author Armin Braun (me@obrown.io)
+ * @version $Id$
+ * @since 1.62
+ */
+public final class ReleaseTagTest {
+
+    /**
+     * ReleaseTag can deny release for outdated, semantically correct versions.
+     * @throws Exception In case of error.
+     */
+    @Test
+    public void validatesReleaseVersion() throws Exception {
+        final Repo repo = new MkGithub().randomRepo();
+        repo.releases().create("1.74");
+        MatcherAssert.assertThat(
+            new ReleaseTag(repo, "1.87.15").release(),
+            Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            new ReleaseTag(repo, "1.5-bar").release(),
+            Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            new ReleaseTag(repo, "1.9-beta").release(),
+            Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            new ReleaseTag(repo, "1.62").release(),
+            Matchers.is(false)
+        );
+    }
+
+    /**
+     * ReleaseTag can retrieve the latest release version in the repo.
+     * @throws Exception In case of error.
+     */
+    @Test
+    public void getsReferenceVersion() throws Exception {
+        final Repo repo = new MkGithub().randomRepo();
+        final String latest = "2.2.1";
+        repo.releases().create("1.0");
+        repo.releases().create(latest);
+        repo.releases().create("3.0-beta");
+        MatcherAssert.assertThat(
+            new ReleaseTag(repo, "2.4").reference(),
+            Matchers.is(latest)
+        );
+    }
+}

--- a/src/test/java/com/rultor/agents/github/qtn/ReleaseTagTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/ReleaseTagTest.java
@@ -53,19 +53,19 @@ public final class ReleaseTagTest {
         final Repo repo = new MkGithub().randomRepo();
         repo.releases().create("1.74");
         MatcherAssert.assertThat(
-            new ReleaseTag(repo, "1.87.15").release(),
+            new ReleaseTag(repo, "1.87.15").allowed(),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
-            new ReleaseTag(repo, "1.5-bar").release(),
+            new ReleaseTag(repo, "1.5-bar").allowed(),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
-            new ReleaseTag(repo, "1.9-beta").release(),
+            new ReleaseTag(repo, "1.9-beta").allowed(),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
-            new ReleaseTag(repo, "1.62").release(),
+            new ReleaseTag(repo, "1.62").allowed(),
             Matchers.is(false)
         );
     }

--- a/src/test/java/com/rultor/agents/github/qtn/ReleaseTagTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/ReleaseTagTest.java
@@ -37,7 +37,6 @@ import org.junit.Test;
 
 /**
  * Tests for ${@link ReleaseTag}.
- *
  * @author Armin Braun (me@obrown.io)
  * @version $Id$
  * @since 1.62
@@ -46,7 +45,9 @@ public final class ReleaseTagTest {
 
     /**
      * ReleaseTag can deny release for outdated, semantically correct versions.
-     * @throws Exception In case of error.
+     * It does however allow any version number, if it contains anything
+     * other than digits and dots.
+     * @throws Exception In case of error
      */
     @Test
     public void validatesReleaseVersion() throws Exception {
@@ -72,7 +73,7 @@ public final class ReleaseTagTest {
 
     /**
      * ReleaseTag can retrieve the latest release version in the repo.
-     * @throws Exception In case of error.
+     * @throws Exception In case of error
      */
     @Test
     public void getsReferenceVersion() throws Exception {


### PR DESCRIPTION
#960 is solved by this:

* Added maven-artifact dependency for its version comparison capabilities
* QnRelease now differentiates 3 cases and answers accordingly
 * no tag given
 * outdated tag
 * tag that is either not a valid version or newer than the most highest valid version tag
* Added class ReleaseTag to encapsulate the version comparison against the repo
* Adjusted and extended QnReleaseTest for the new differentiation between 3 cases
* Added ReleaseTagTest for the new ReleaseTag class