### PR TITLE
#935 create a new branch from origin target branch,so that git does not fail the checkout because of ambiguous naming

### DIFF
--- a/src/main/resources/com/rultor/agents/req/merge.sh
+++ b/src/main/resources/com/rultor/agents/req/merge.sh
@@ -19,9 +19,8 @@ while [ $(git show-branch "${BRANCH}" 2>/dev/null | wc -l) -gt 0 ]; do
   export BRANCH="__rultor-$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 16)"
 done
 
-git checkout "fork/${fork_branch}"
-git checkout -b "${BRANCH}"
-git checkout "${head_branch}"
+git checkout -B "${BRANCH}" "fork/${fork_branch}"
+git checkout -B "${head_branch}" "origin/${head_branch}"
 
 if [ "${rebase}" == "true" ]; then
   git checkout "${BRANCH}"


### PR DESCRIPTION
#935 is resolved by this.

Very straightforward fix in my opinion, this is essentially the same fix as the one reverted here https://github.com/yegor256/rultor/commit/e022a224f51f137e38090f4ea582bd952712e3c3.

The problem with that one was that if you have the same branch name in both remotes and checkout this way:
```bash
git checkout "origin/${head_branch}"
```

you're left in a detached head state. 
Added the `-B` flag that will automatically either create or hard reset the branch to the given remote to prevent this now and it should work fine.