### PR TITLE
Exclude settings.xml from copyright check to fix release

### DIFF
--- a/years.sh
+++ b/years.sh
@@ -2,7 +2,7 @@
 
 if (grep -r "Copyright \+(c) \+2009-.*rultor.com" \
   --exclude-dir "target" --exclude-dir ".git" --exclude "years.sh" \
-  --exclude-dir ".idea" \
+  --exclude-dir ".idea" --exclude "settings.xml" \
   --exclude-dir "apache-maven-*" . | grep -v 2009-`date +%Y`); then
     echo "Files above have wrong years in copyrights"
     exit 1
@@ -12,7 +12,7 @@ if (grep -r -L "Copyright \+(c) \+2009-.*rultor.com" \
   --include=*.java --include=*.xml --include=*.vm --include=*.groovy \
   --include=*.txt --include=*.fml --include=*.properties} \
   --exclude-dir "target" --exclude-dir "apache-maven-*" . \
-  --exclude-dir ".idea" \
+  --exclude-dir ".idea" --exclude "settings.xml" \
   | grep -v 2009-`date +%Y`); then
     echo "Files above must have copyright block in header"
     exit 1


### PR DESCRIPTION
We missed this when we added the year check, the settings.xml is copied into this folder only when releasing, but it's breaking the release now that it's getting checked for copyright.