### PR TITLE
#864 Correctly handle situation when report is created for stopped command.

### DIFF
--- a/src/main/java/com/rultor/agents/github/Reports.java
+++ b/src/main/java/com/rultor/agents/github/Reports.java
@@ -106,7 +106,17 @@ public final class Reports extends AbstractAgent {
             msg.append(Reports.tail(req));
         }
         final int number = Integer.parseInt(req.xpath("@id").get(0));
-        new Answer(Reports.origin(issue, number)).post(success, msg.toString());
+        final Comment.Smart comment = Reports.origin(issue, number);
+        final String message;
+        if (comment.body().contains("stop")) {
+            message = String.format(
+                Reports.PHRASES.getString("Reports.stop-fails"),
+                msg.toString()
+            );
+        } else {
+            message = msg.toString();
+        }
+        new Answer(comment).post(success, message);
         Logger.info(this, "issue #%d reported: %B", issue.number(), success);
         return new Directives()
             .xpath("/talk/request[success]")

--- a/src/main/resources/phrases_en_US.properties
+++ b/src/main/resources/phrases_en_US.properties
@@ -75,6 +75,7 @@ QnVersion.intro=My current version is %s, \
 
 Reports.success=Done! FYI, the full log is [here](%s) (took me %[ms]s)
 Reports.failure=Oops, I failed. You can see the full log [here](%s) (spent %[ms]s)
+Reports.stop-fails=Sorry, I failed to stop the previous command, however it has next result: %s
 
 CommentsTag.duplicate=Release `%s` already exists! I can't duplicate it, \
     but I posted a comment there. In the future, try to avoid duplicate releases


### PR DESCRIPTION
#864 I fixed Rultor behavior for situation when report is created for stopped command. Now it will add string: `Sorry, I failed to stop the previous command, however it has next result:` to report message. I also added test to check this.