### PR TITLE
#1041 implemented docker daemon host health check

### DIFF
--- a/src/main/java/com/rultor/agents/docker/DockerHealthCheck.java
+++ b/src/main/java/com/rultor/agents/docker/DockerHealthCheck.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2009-2016, rultor.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the rultor.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.rultor.agents.docker;
+
+import com.jcabi.log.Logger;
+import com.jcabi.ssh.Shell;
+import com.rultor.spi.SuperAgent;
+import com.rultor.spi.Talks;
+import java.io.IOException;
+import java.util.logging.Level;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.NullInputStream;
+
+/**
+ * Checks the Health of a Docker host and tries to recover Docker daemon
+ * crashes.
+ * @author Armin Braun (me@obrown.io)
+ * @version $Id$
+ * @since 1.63
+ * @todo #1041:30min Add DockerHealthCheck to the running SuperAgents.
+ *   In doing so make sure that Rultor crashes throwing a meaningful exception
+ *   as soon as DockerHealthCheck#execute throws and exception.
+ *   #1041 has the details on the motivation behind this agent.
+ */
+public final class DockerHealthCheck implements SuperAgent {
+
+    /**
+     * Shell to use.
+     */
+    private final transient Shell shell;
+
+    /**
+     * Ctor.
+     * @param ssh Shell
+     */
+    public DockerHealthCheck(final Shell ssh) {
+        this.shell = ssh;
+    }
+
+    @Override
+    public void execute(final Talks talks) throws IOException {
+        new Shell.Safe(this.shell).exec(
+            IOUtils.toString(
+                this.getClass().getResourceAsStream("checkhost.sh")
+            ),
+            new NullInputStream(0L),
+            Logger.stream(Level.INFO, this),
+            Logger.stream(Level.WARNING, this)
+        );
+    }
+
+}

--- a/src/main/java/com/rultor/agents/docker/DockerHealthCheck.java
+++ b/src/main/java/com/rultor/agents/docker/DockerHealthCheck.java
@@ -45,9 +45,9 @@ import org.apache.commons.io.input.NullInputStream;
  * @version $Id$
  * @since 1.63
  * @todo #1041:30min Add DockerHealthCheck to the running SuperAgents.
- *   In doing so make sure that Rultor crashes throwing a meaningful exception
- *   as soon as DockerHealthCheck#execute throws and exception.
- *   #1041 has the details on the motivation behind this agent.
+ *  In doing so make sure that Rultor crashes throwing a meaningful exception
+ *  as soon as DockerHealthCheck#execute throws and exception.
+ *  #1041 has the details on the motivation behind this agent.
  */
 public final class DockerHealthCheck implements SuperAgent {
 

--- a/src/main/resources/com/rultor/agents/docker/checkhost.sh
+++ b/src/main/resources/com/rultor/agents/docker/checkhost.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+command -v git >/dev/null 2>&1 || { echo "Rultor requires Git to be installed on the SSH host, but the git command was not found. Aborting ..."; exit 1; }
+command -v docker >/dev/null 2>&1 || { echo "Rultor requires Docker to be installed on the SSH host, but the docker command was not found. Aborting ..."; exit 1; }
+command -v sudo >/dev/null 2>&1 || { echo "Rultor requires Sudo to be installed on the SSH host, but the sudo command was not found. Aborting ..."; exit 1; }
+if ! sudo -n true 2>/dev/null
+ then
+    echo "Rultor requires passwordless sudo on the SSH host, but this host requires a password. Aborting ..."; exit 1;
+fi
+
+docker info >/dev/null 2>&1 || sudo -n service docker restart >/dev/null 2>&1  || { echo >&2 "Rultor requires the Docker cli client to be connected to a working Docker daemon. The Docker cli client on this host appears to not be connected to a working daemon! Aborting ..."; exit 1; }

--- a/src/test/java/com/rultor/agents/docker/DockerHealthCheckTest.java
+++ b/src/test/java/com/rultor/agents/docker/DockerHealthCheckTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2009-2016, rultor.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the rultor.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.rultor.agents.docker;
+
+import com.jcabi.ssh.Shell;
+import com.rultor.spi.Talks;
+import java.io.InputStream;
+import java.io.OutputStream;
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Tests for ${@link DockerHealthCheck}.
+ *
+ * @author Armin Braun (me@obrown.io)
+ * @version $Id$
+ * @since 1.63
+ */
+public final class DockerHealthCheckTest {
+
+    /**
+     * DockerHealthCheckTest can execute checkhost.sh.
+     * @throws Exception In case of error
+     */
+    @Test
+    public void runsCheckHostScript() throws Exception {
+        final Shell shell = Mockito.mock(Shell.class);
+        new DockerHealthCheck(shell).execute(Mockito.mock(Talks.class));
+        Mockito.verify(shell).exec(
+            Mockito.eq(
+                IOUtils.toString(
+                    DockerHealthCheck.class.getResourceAsStream("checkhost.sh")
+                )
+            ),
+            Mockito.any(InputStream.class),
+            Mockito.any(OutputStream.class),
+            Mockito.any(OutputStream.class)
+        );
+    }
+
+}

--- a/src/test/java/com/rultor/agents/docker/package-info.java
+++ b/src/test/java/com/rultor/agents/docker/package-info.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2009-2016, rultor.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the rultor.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Docker daemon, tests.
+ *
+ * @author Armin Braun (me@obrown.io)
+ * @version $Id$
+ * @since 1.63
+ */
+package com.rultor.agents.docker;


### PR DESCRIPTION
#1041 is resolved by this.

* Added script that needs to `exit 0` on a working Rultor SSH host.
* Added `SuperAgent` executing this script
* Added Test describing the `SuperAgent` behavior
* Added puzzle for integrating this with the existing SuperAgents