### PR TITLE
#1039 Use merged and validated of version `.rultor.yml` for `merge` command.

### DIFF
--- a/src/main/java/com/rultor/profiles/Profiles.java
+++ b/src/main/java/com/rultor/profiles/Profiles.java
@@ -32,7 +32,6 @@ package com.rultor.profiles;
 import com.jcabi.aspects.Cacheable;
 import com.jcabi.aspects.Immutable;
 import com.jcabi.aspects.Tv;
-import com.jcabi.github.Coordinates;
 import com.jcabi.github.Github;
 import com.jcabi.github.RtGithub;
 import com.jcabi.github.wire.RetryCarefulWire;
@@ -42,6 +41,7 @@ import com.rultor.agents.github.TalkIssues;
 import com.rultor.spi.Profile;
 import com.rultor.spi.Talk;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -59,6 +59,11 @@ import lombok.ToString;
 public final class Profiles {
 
     /**
+     * Merge command.
+     */
+    private static final String MERGE = "merge";
+
+    /**
      * Fetch a profile from a talk.
      * @param talk The talk
      * @return Profile found
@@ -73,33 +78,107 @@ public final class Profiles {
             if (xml.nodes("/talk/wire").isEmpty()) {
                 profile = Profile.EMPTY;
             } else {
-                profile = Profiles.fetch(xml);
+                profile = this.fetch(xml);
             }
         }
         return profile;
     }
 
     /**
+     * Merge profile from master and fork. Merged profile must be profile
+     * from fork, but all lists for commanders and architects must be taken
+     * from master branch.
+     * @param master Profile from master branch
+     * @param fork Fork that will be merged
+     * @param branch Fork branch that will be merged
+     * @return Merged profile
+     */
+    public Profile merged(final Profile master, final String fork,
+        final String branch) {
+        return master;
+    }
+
+    /**
+     * Validate merged profile: merged profile must have no changes in architect
+     * and commander sections (full match with master profile).
+     * @param master Profile from master branch
+     * @param merged Result of merging master and fork profiles
+     * @return Validated profile
+     * @throws IOException If fails
+     * @todo #1039:30min Add integration test to  be sure that validation
+     *  exception will eventually be posted as an Answer in GitHub.
+     *  After you create integration test, add `validated` method call in
+     *  `fetch` method: `...this.validated(master, this.merged(...`.
+     *  Modify `merged` method implementation: merged profile is a
+     *  `.rultor.yml` form result of real `git merge` of master branch and
+     *  fork branch. We need real `git merge` result here. See some details
+     *  here: https://github.com/yegor256/rultor/pull/1064/files#r56796959
+     */
+    public Profile validated(final Profile master, final Profile merged)
+        throws IOException {
+        final String commanders = "commanders";
+        final String[][] security = {
+            {"architect"},
+            {Profiles.MERGE, commanders},
+            {"deploy", commanders},
+            {"release", commanders},
+        };
+        for (final String[] section : security) {
+            if (!Arrays.equals(
+                Profiles.section(master, section),
+                Profiles.section(merged, section)
+            )) {
+                throw new Profile.ConfigException(
+                    String.format(
+                        "You cannot change `%s` section for security reasons",
+                        Arrays.toString(section)
+                    )
+                );
+            }
+        }
+        return merged;
+    }
+
+    /**
+     * Get section content.
+     * @param profile Profile
+     * @param section Section of profile
+     * @return Content of section as array of strings
+     * @throws IOException If fails
+     */
+    private static String[] section(final Profile profile,
+        final String... section)
+        throws IOException {
+        final StringBuilder path = new StringBuilder(Tv.HUNDRED);
+        for (final String element : section) {
+            path.append(String.format("/entry[@key='%s']", element));
+        }
+        final List<String> result = profile.read().xpath(
+            String.format("/%s/item/text()", path.toString())
+        );
+        return result.toArray(new String[result.size()]);
+    }
+
+    /**
      * Fetch a profile from an XML.
      * @param xml The XML
      * @return Profile found
+     * @throws IOException If fails
      */
-    private static Profile fetch(final XML xml) {
+    private Profile fetch(final XML xml) throws IOException {
         final Profile profile;
         final List<String> type = xml.xpath("//request/type/text()");
-        if (type.isEmpty() || !"merge".equals(type.get(0))) {
+        if (type.isEmpty() || !Profiles.MERGE.equals(type.get(0))) {
             profile = new GithubProfile(
                 new TalkIssues(Profiles.github(), xml).get().repo()
             );
         } else {
-            profile = new GithubProfile(
-                Profiles.github().repos().get(
-                    new Coordinates.Simple(
-                        xml.xpath(
-                            "//request/args/arg[@name='fork']/text()"
-                        ).get(0)
-                    )
-                ),
+            final Profile master = new GithubProfile(
+                    new TalkIssues(Profiles.github(), xml).get().repo()
+            );
+            profile = this.merged(
+                master,
+                xml.xpath("//request/args/arg[@name='fork']/text()").get(0),
                 xml.xpath(
                     "//request/args/arg[@name='fork_branch']/text()"
                 ).get(0)

--- a/src/main/java/com/rultor/profiles/Profiles.java
+++ b/src/main/java/com/rultor/profiles/Profiles.java
@@ -173,11 +173,10 @@ public final class Profiles {
                 new TalkIssues(Profiles.github(), xml).get().repo()
             );
         } else {
-            final Profile master = new GithubProfile(
-                    new TalkIssues(Profiles.github(), xml).get().repo()
-            );
             profile = this.merged(
-                master,
+                new GithubProfile(
+                        new TalkIssues(Profiles.github(), xml).get().repo()
+                ),
                 xml.xpath("//request/args/arg[@name='fork']/text()").get(0),
                 xml.xpath(
                     "//request/args/arg[@name='fork_branch']/text()"

--- a/src/test/java/com/rultor/profiles/ProfilesTest.java
+++ b/src/test/java/com/rultor/profiles/ProfilesTest.java
@@ -1,0 +1,321 @@
+/**
+ * Copyright (c) 2009-2016, rultor.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the rultor.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.rultor.profiles;
+
+import com.jcabi.xml.XMLDocument;
+import com.rultor.spi.Profile;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for ${@link Profiles}.
+ * @author Maksimenko Vladimir (xupypr@xupypr.com)
+ * @version $Id$
+ * @since 1.62
+ */
+public class ProfilesTest {
+
+    /**
+     * Commanders section.
+     */
+    private static final String COMMANDERS =
+        "<entry key='commanders'><item>%s</item></entry>";
+
+    /**
+     * Script section.
+     */
+    private static final String SCRIPT =
+        "<entry key='script'><item>%s</item></entry>";
+
+    /**
+     * Commanders of merge section.
+     */
+    private static final String MERGE_COMMANDERS = "[merge, commanders]";
+
+    /**
+     * Profile template.
+     */
+    private static final String PROFILE = StringUtils.join(
+        "<p><entry key='architect'><item>%s</item></entry>",
+        "<entry key='merge'>",
+        ProfilesTest.COMMANDERS,
+        ProfilesTest.SCRIPT,
+        "</entry><entry key='deploy'>",
+        ProfilesTest.COMMANDERS,
+        "</entry><entry key='release'>",
+        ProfilesTest.COMMANDERS,
+        "</entry></p>"
+    );
+
+    /**
+     * Template for exception message.
+     */
+    private static final String MESSAGE =
+        "You cannot change `%s` section for security reasons";
+
+    /**
+     * Profiles can restrict changes in architect section.
+     * @throws Exception In case of error.
+     */
+    @Test
+    public final void validationFailsOnArchitectsMismatch() throws Exception {
+        final String commander = "Yegor1024";
+        final Profile master = new Profile.Fixed(
+            new XMLDocument(
+                String.format(
+                    ProfilesTest.PROFILE,
+                    "Yegor64",
+                    commander,
+                    "do_something",
+                    commander,
+                    commander
+                )
+            )
+        );
+        final Profile merged = new Profile.Fixed(
+            new XMLDocument(
+                String.format(
+                    ProfilesTest.PROFILE,
+                    "Bobby",
+                    commander,
+                    "do_another",
+                    commander,
+                    commander
+                )
+            )
+        );
+        try {
+            new Profiles().validated(master, merged);
+            Assert.fail("Code above must throw an exception");
+        } catch (final Profile.ConfigException exception) {
+            MatcherAssert.assertThat(
+                exception.getMessage(),
+                Matchers.is(
+                    String.format(
+                        ProfilesTest.MESSAGE,
+                        "[architect]"
+                    )
+                )
+            );
+        }
+    }
+
+    /**
+     * Profiles can restrict changes in merge/commanders section.
+     * @throws Exception In case of error.
+     */
+    @Test
+    public final void validationFailsOnCommandersMismatch() throws Exception {
+        final String architect = "Yegor2048";
+        final String commander = "Yegor4096";
+        final Profile master = new Profile.Fixed(
+            new XMLDocument(
+                String.format(
+                    ProfilesTest.PROFILE,
+                    architect,
+                    "Yegor32",
+                    "do_something2",
+                    "Yegor16",
+                    commander
+                )
+            )
+        );
+        final Profile merged = new Profile.Fixed(
+            new XMLDocument(
+                String.format(
+                    ProfilesTest.PROFILE,
+                    architect,
+                    "Bob",
+                    "do_another2",
+                    "Marley",
+                    commander
+                )
+            )
+        );
+        try {
+            new Profiles().validated(master, merged);
+            Assert.fail("Method above must throw an exception");
+        } catch (final Profile.ConfigException exception) {
+            MatcherAssert.assertThat(
+                exception.getMessage(),
+                Matchers.is(
+                    String.format(
+                        ProfilesTest.MESSAGE,
+                        ProfilesTest.MERGE_COMMANDERS
+                    )
+                )
+            );
+        }
+    }
+
+    /**
+     * Profiles can restrict changes in commanders section in case when
+     * overall commanders list is still the same (commander moved from one
+     * section to another).
+     * @throws Exception In case of error.
+     */
+    @Test
+    public final void validationFailsOnCommandersMix() throws Exception {
+        final String architect = "Yegor8192";
+        final String first = "Commander Keen";
+        final String second = "Commander Shepard";
+        final Profile master = new Profile.Fixed(
+            new XMLDocument(
+                String.format(
+                    ProfilesTest.PROFILE,
+                    architect,
+                    first,
+                    "do_something4",
+                    second,
+                    second
+                )
+            )
+        );
+        final Profile merged = new Profile.Fixed(
+            new XMLDocument(
+                String.format(
+                    StringUtils.join(
+                        "<p><entry key='architect'><item>%s</item>",
+                        "</entry><entry key='merge'>",
+                        "<entry key='commanders'>",
+                        "<item>%s</item><item>%s</item><item>%s</item>",
+                        "</entry>",
+                        ProfilesTest.SCRIPT,
+                        "</entry> </p>"
+                    ),
+                    architect,
+                    first,
+                    second,
+                    second,
+                    "do_another4"
+                )
+            )
+        );
+        try {
+            new Profiles().validated(master, merged);
+            Assert.fail("Line above must throw an exception");
+        } catch (final Profile.ConfigException exception) {
+            MatcherAssert.assertThat(
+                exception.getMessage(),
+                Matchers.is(
+                    String.format(
+                        ProfilesTest.MESSAGE,
+                        ProfilesTest.MERGE_COMMANDERS
+                    )
+                )
+            );
+        }
+    }
+
+    /**
+     * Profiles can validate merged profile without changes in restricted
+     * sections.
+     * @throws Exception In case of error.
+     */
+    @Test
+    public final void validationReturnsMerged() throws Exception {
+        final String architect = "Yegor512";
+        final String first = "Total Commander";
+        final String second = "Midnight Commander";
+        final String third = "Norton Commander";
+        final String script = "do_another3";
+        final Profile master = new Profile.Fixed(
+            new XMLDocument(
+                String.format(
+                    ProfilesTest.PROFILE,
+                    architect,
+                    first,
+                    "do_something3",
+                    second,
+                    third
+                )
+            )
+        );
+        final Profile fork = new Profile.Fixed(
+            new XMLDocument(
+                String.format(
+                    ProfilesTest.PROFILE,
+                    architect,
+                    first,
+                    script,
+                    second,
+                    third
+                )
+            )
+        );
+        final Profile validated = new Profiles().validated(master, fork);
+        final List<String> architects = validated.read().xpath(
+            "//entry[@key='architect']/item/text()"
+        );
+        MatcherAssert.assertThat(
+            "Architect is taken from master",
+            architects,
+            Matchers.contains(architect)
+        );
+        final String path =
+                "//entry[@key='%s']/entry[@key='commanders']/item/text()";
+        final List<String> merge = validated.read().xpath(
+            String.format(path, "merge")
+        );
+        MatcherAssert.assertThat(
+            "Merge commander is taken from master",
+            merge,
+            Matchers.contains(first)
+        );
+        final List<String> deploy = validated.read().xpath(
+            String.format(path, "deploy")
+        );
+        MatcherAssert.assertThat(
+            "Deploy commander is taken from master",
+            deploy,
+            Matchers.contains(second)
+        );
+        final List<String> release = validated.read().xpath(
+            String.format(path, "release")
+        );
+        MatcherAssert.assertThat(
+            "Release commander is taken from master",
+            release,
+            Matchers.contains(third)
+        );
+        final List<String> scripts = validated.read().xpath(
+            "//entry[@key='merge']/entry[@key='script']/item/text()"
+        );
+        MatcherAssert.assertThat(
+            "Script is taken from fork",
+            scripts,
+            Matchers.contains(script)
+        );
+    }
+}


### PR DESCRIPTION
#1039 I implemented validated method, that checks that merged .rultor.yml has no changes in architect and commander sections. I covered `validated` method by unit tests. I added one puzzle (to implement `merged` method, write IT for `validated` method and use it.

This is a copy of https://github.com/yegor256/rultor/pull/1064 that cannot be reopened. That's why I created new one.