### PR TITLE
#1060 Rultor needs to be Dockerized.

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -75,6 +75,3 @@ release:
   commanders:
   - original-brownbear
   - yegor256
-docker:
-  directory: yegor256/rultor-git
-  as_root: true

--- a/.rultor.yml
+++ b/.rultor.yml
@@ -75,3 +75,6 @@ release:
   commanders:
   - original-brownbear
   - yegor256
+docker:
+  directory: yegor256/rultor-git
+  as_root: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,3 +3,5 @@ FROM ubuntu:14.04
 MAINTAINER Dali Freire
 
 ENV GIT_SSH_COMMAND ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+
+RUN apt-get update && apt-get install -y git

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,4 @@ FROM ubuntu:14.04
 
 MAINTAINER Dali Freire
 
-USER root
-
 ENV GIT_SSH_COMMAND ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:14.04
+
+MAINTAINER Dali Freire
+
+USER root
+
+ENV GIT_SSH_COMMAND ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no

--- a/git
+++ b/git
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker run -t --rm -v "${PWD}":"${PWD}" ~/.ssh:"/root/.ssh":ro yegor256/rultor-git git "$@"


### PR DESCRIPTION
Issue #1060 - Rultor`s Git Use Needs to be Dockerized

- Creates the Dockefile defining the base image to 'ubuntu/14:04'