### PR TITLE
#1052 Not check for deprecation messages in special case

### DIFF
--- a/src/test/java/com/rultor/agents/daemons/StartsDaemonITCase.java
+++ b/src/test/java/com/rultor/agents/daemons/StartsDaemonITCase.java
@@ -49,6 +49,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.input.NullInputStream;
 import org.apache.commons.lang3.CharEncoding;
 import org.apache.commons.lang3.SystemUtils;
+import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.StringStartsWith;
@@ -67,6 +68,7 @@ import org.xembly.Directives;
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
+@SuppressWarnings("PMD.ExcessiveImports")
 public final class StartsDaemonITCase {
 
     /**
@@ -126,16 +128,18 @@ public final class StartsDaemonITCase {
         final XML xml = talk.read();
         final String dir = xml.xpath("/talk/daemon/dir/text()").get(0);
         final List<String> repos = xml.xpath("/wire/github-repo/text()");
+        final String notice = "#### Deprecation Notice ####";
+        final Matcher<String> matcher;
         if ((repos.isEmpty() || !rultor.equals(repos.get(0)))
             && xml.xpath(
                 "/p/entry[@key='merge']/entry[@key='script']"
             ).contains(rultor)
         ) {
-            MatcherAssert.assertThat(
-                dir,
-                StringStartsWith.startsWith("#### Deprecation Notice ####")
-            );
+            matcher = StringStartsWith.startsWith(notice);
+        } else {
+            matcher = Matchers.not(StringStartsWith.startsWith(notice));
         }
+        MatcherAssert.assertThat(dir, matcher);
     }
 
     /**

--- a/src/test/java/com/rultor/agents/daemons/StartsDaemonITCase.java
+++ b/src/test/java/com/rultor/agents/daemons/StartsDaemonITCase.java
@@ -115,27 +115,31 @@ public final class StartsDaemonITCase {
     }
 
     /**
-     * StartsDaemon can deprecate default image.
+     * StartsDaemon can deprecate default image (except one case, when
+     * repo is is the actual Rultor repo: https://github.com/yegor256/rultor).
      * @throws IOException In case of error
-     * @todo #1018:30min This test should not check for start and end
-     *  deprecation messages if when the repo is the actual Rultor repo:
-     *  https://github.com/yegor256/rultor
      */
     @Test
     @Ignore
     public void deprecatesDefaultImage() throws IOException {
         final Talk talk = this.talk();
         final XML xml = talk.read();
-        for (final String path
-            : xml.xpath("/p/entry[@key='merge']/entry[@key='script']")
-             ) {
-            if ("yegor256/rultor".equals(path)) {
-                final String dir = talk.read()
-                    .xpath("/talk/daemon/dir/text()").get(0);
-                MatcherAssert.assertThat(
-                    dir,
-                    StringStartsWith.startsWith("#### Deprecation Notice ####")
-                );
+        if (!"yegor256/rultor".equals(
+            xml.xpath("/wire/github-repo/text()").get(0)
+        )) {
+            for (final String path
+                : xml.xpath("/p/entry[@key='merge']/entry[@key='script']")
+                 ) {
+                if ("yegor256/rultor".equals(path)) {
+                    final String dir = talk.read()
+                        .xpath("/talk/daemon/dir/text()").get(0);
+                    MatcherAssert.assertThat(
+                        dir,
+                        StringStartsWith.startsWith(
+                            "#### Deprecation Notice ####"
+                        )
+                    );
+                }
             }
         }
     }

--- a/src/test/java/com/rultor/agents/daemons/StartsDaemonITCase.java
+++ b/src/test/java/com/rultor/agents/daemons/StartsDaemonITCase.java
@@ -70,6 +70,11 @@ import org.xembly.Directives;
 public final class StartsDaemonITCase {
 
     /**
+     * Rultor repo.
+     */
+    private static final String RULTOR = "yegor256/rultor";
+
+    /**
      * Temp directory.
      * @checkstyle VisibilityModifierCheck (5 lines)
      */
@@ -124,13 +129,17 @@ public final class StartsDaemonITCase {
     public void deprecatesDefaultImage() throws IOException {
         final Talk talk = this.talk();
         final XML xml = talk.read();
-        if (!"yegor256/rultor".equals(
-            xml.xpath("/wire/github-repo/text()").get(0)
-        )) {
-            for (final String path
-                : xml.xpath("/p/entry[@key='merge']/entry[@key='script']")
-                 ) {
-                if ("yegor256/rultor".equals(path)) {
+        if (
+            !StartsDaemonITCase.RULTOR.equals(
+                xml.xpath("/wire/github-repo/text()").get(0)
+            )
+        ) {
+            for (
+                final String path : xml.xpath(
+                    "/p/entry[@key='merge']/entry[@key='script']"
+                )
+            ) {
+                if (StartsDaemonITCase.RULTOR.equals(path)) {
                     final String dir = talk.read()
                         .xpath("/talk/daemon/dir/text()").get(0);
                     MatcherAssert.assertThat(

--- a/src/test/java/com/rultor/agents/daemons/StartsDaemonITCase.java
+++ b/src/test/java/com/rultor/agents/daemons/StartsDaemonITCase.java
@@ -128,8 +128,10 @@ public final class StartsDaemonITCase {
     public void deprecatesDefaultImage() throws IOException {
         final Talk talk = this.talk();
         final XML xml = talk.read();
-        final List<String> repo = xml.xpath("/wire/github-repo/text()");
-        if (repo.isEmpty() || !StartsDaemonITCase.RULTOR.equals(repo.get(0))) {
+        final List<String> repos = xml.xpath("/wire/github-repo/text()");
+        if (
+            repos.isEmpty() || !StartsDaemonITCase.RULTOR.equals(repos.get(0))
+        ) {
             for (
                 final String path : xml.xpath(
                     "/p/entry[@key='merge']/entry[@key='script']"

--- a/src/test/java/com/rultor/agents/daemons/StartsDaemonITCase.java
+++ b/src/test/java/com/rultor/agents/daemons/StartsDaemonITCase.java
@@ -44,6 +44,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.input.NullInputStream;
 import org.apache.commons.lang3.CharEncoding;
@@ -52,7 +53,6 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.StringStartsWith;
 import org.junit.Assume;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -125,15 +125,11 @@ public final class StartsDaemonITCase {
      * @throws IOException In case of error
      */
     @Test
-    @Ignore
     public void deprecatesDefaultImage() throws IOException {
         final Talk talk = this.talk();
         final XML xml = talk.read();
-        if (
-            !StartsDaemonITCase.RULTOR.equals(
-                xml.xpath("/wire/github-repo/text()").get(0)
-            )
-        ) {
+        final List<String> repo = xml.xpath("/wire/github-repo/text()");
+        if (repo.isEmpty() || !StartsDaemonITCase.RULTOR.equals(repo.get(0))) {
             for (
                 final String path : xml.xpath(
                     "/p/entry[@key='merge']/entry[@key='script']"

--- a/src/test/java/com/rultor/agents/daemons/StartsDaemonITCase.java
+++ b/src/test/java/com/rultor/agents/daemons/StartsDaemonITCase.java
@@ -70,11 +70,6 @@ import org.xembly.Directives;
 public final class StartsDaemonITCase {
 
     /**
-     * Rultor repo.
-     */
-    private static final String RULTOR = "yegor256/rultor";
-
-    /**
      * Temp directory.
      * @checkstyle VisibilityModifierCheck (5 lines)
      */
@@ -126,28 +121,20 @@ public final class StartsDaemonITCase {
      */
     @Test
     public void deprecatesDefaultImage() throws IOException {
+        final String rultor = "yegor256/rultor";
         final Talk talk = this.talk();
         final XML xml = talk.read();
+        final String dir = xml.xpath("/talk/daemon/dir/text()").get(0);
         final List<String> repos = xml.xpath("/wire/github-repo/text()");
-        if (
-            repos.isEmpty() || !StartsDaemonITCase.RULTOR.equals(repos.get(0))
+        if ((repos.isEmpty() || !rultor.equals(repos.get(0)))
+            && xml.xpath(
+                "/p/entry[@key='merge']/entry[@key='script']"
+            ).contains(rultor)
         ) {
-            for (
-                final String path : xml.xpath(
-                    "/p/entry[@key='merge']/entry[@key='script']"
-                )
-            ) {
-                if (StartsDaemonITCase.RULTOR.equals(path)) {
-                    final String dir = talk.read()
-                        .xpath("/talk/daemon/dir/text()").get(0);
-                    MatcherAssert.assertThat(
-                        dir,
-                        StringStartsWith.startsWith(
-                            "#### Deprecation Notice ####"
-                        )
-                    );
-                }
-            }
+            MatcherAssert.assertThat(
+                dir,
+                StringStartsWith.startsWith("#### Deprecation Notice ####")
+            );
         }
     }
 


### PR DESCRIPTION
#1052 `StartsDaemonITCase` class, `deprecatesDefaultImage` method. Avoid checking deprecation messages when the repo is the actual Rultor repo: https://github.com/yegor256/rultor . Also I removed `@Ignore` annotation from test.