### PR TITLE
#1088 removed obsolete puzzle

### DIFF
--- a/src/main/java/com/rultor/agents/ecs/StartsECS.java
+++ b/src/main/java/com/rultor/agents/ecs/StartsECS.java
@@ -51,10 +51,6 @@ import org.xembly.Directives;
  * @todo #629 Implement com.rultor.agents.ecs.StopsECS agent. It must
  *  stop ECS on-demand container if it was started at StartsECS agent.
  *  StopsECS must use container ARN from /talk/ec2/[@id] to stop it.
- * @todo #629 RegistersShell must register SSH params "host", "port",
- *  "login", "key" for ecs on-demand container, if this one was successfully
- *  started. Successfully start means that these parameters exist in
- *  /talk/ec2
  * @todo #629 Add new container creation classes for StartsECS and StopsECS
  *  to com.rultor.agents.Agents. StartsECS must be invoked before
  *  RegistersShell agent. StopsECS must be invoked after RemovesShell agent.


### PR DESCRIPTION
#1088 is resolved here

This is obsolete, we have exactly this from work invested in the test basics here `com.rultor.agents.docker.StartsDockerDaemon`.
`com.rultor.agents.docker.StartsDockerDaemon#shell` does now return a `PfShell`, which we can use as the inputs to `com.rultor.agents.shells.RegistersShell#RegistersShell` once ECS is fully implemented at no cost.