### PR TITLE
#1125 Preventing 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@
         <dependency>
             <groupId>com.jcabi</groupId>
             <artifactId>jcabi-http</artifactId>
-            <version>1.16</version>
+            <version>1.14.2</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>
@@ -273,7 +273,7 @@
         <dependency>
             <groupId>com.jcabi</groupId>
             <artifactId>jcabi-github</artifactId>
-            <version>0.28</version>
+            <version>0.26</version>
         </dependency>
         <dependency>
             <groupId>com.jcabi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@
         <dependency>
             <groupId>com.jcabi</groupId>
             <artifactId>jcabi-http</artifactId>
-            <version>1.14.2</version>
+            <version>1.16</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>
@@ -273,7 +273,7 @@
         <dependency>
             <groupId>com.jcabi</groupId>
             <artifactId>jcabi-github</artifactId>
-            <version>0.26</version>
+            <version>0.28</version>
         </dependency>
         <dependency>
             <groupId>com.jcabi</groupId>

--- a/src/main/java/com/rultor/Routine.java
+++ b/src/main/java/com/rultor/Routine.java
@@ -56,6 +56,16 @@ import javax.validation.constraints.NotNull;
  * @author Yegor Bugayenko (yegor@teamed.io)
  * @version $Id$
  * @since 1.50
+ * @todo #1125:30min Routine should be delegate execution to separate threads.
+ *  Currently com.rultor.Routine#process() is sequentially processing all Talks
+ *  and breaking out of this sequential processing to log occurring exceptions.
+ *  This leads to issues in one build breaking all builds globally.
+ *  This should be reworked to run the chain of Agents for each talk in a
+ *  separate thread, not interfering with the main Routine in error cases.
+ *  Once this is done the swallowing of generic exceptions, added to
+ *  circumvent this issue, in
+ *  com.rultor.agents.github.Reports#process(com.jcabi.xml.XML) should be
+ *  removed.
  */
 @ScheduleWithFixedDelay(delay = 1, unit = TimeUnit.MINUTES, threads = 1)
 @SuppressWarnings("PMD.DoNotUseThreads")


### PR DESCRIPTION
Quick fix for #1125 and puzzle asking for a lasting solution to this design issue.

The problem here is with `comment.body()` throwing an `AssertionException` since `RtJson` eventually runs this:

```java
    public JsonObject fetch() throws IOException {
        return this.request.fetch()
            .as(RestResponse.class)
            .assertStatus(HttpURLConnection.HTTP_OK)
            .as(JsonResponse.class)
            .json().readObject();
    }
```

which gives us `AssertionException` if the initial deletion of the comment causes a `404` when Rultor tries to retrieve it.
In general these errors should not cause Rultor to globally die, but I don't have the time to handle this in a safe manner on short notice today. Hence I added the puzzle asking for a proper change in design here, preventing this and similar issues in the first place.