### PR TITLE
Test the docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,5 @@ env:
     - JAVA_OPTS="-XX:MaxPermSize=2g -Xmx4g -Dfile.encoding=UTF-8"
 script:
   - mvn clean install -Pqulice -PdockerITs --errors
+  - travis_wait docker build -q -t rultor -f src/docker/Dockerfile src/docker
+  - docker images

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -66,8 +66,7 @@ RUN apt-get install -y ssh && \
 RUN apt-get update && apt-get install -y libmagic-dev=1:5.14-2ubuntu3.3 \
     zlib1g-dev=1:1.2.8.dfsg-1ubuntu1
 RUN apt-add-repository ppa:brightbox/ruby-ng
-RUN apt-get update && apt-get install -y ruby2.2=2.2.4-1bbox1~trusty1 \
-    ruby2.2-dev=2.2.4-1bbox1~trusty1
+RUN apt-get update && apt-get install -y ruby2.2 ruby2.2-dev
 RUN gem update && gem install nokogiri:1.6.7.2 && gem install bundler:1.11.2
 
 # PHP

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -87,11 +87,11 @@ RUN mkdir jsl && \
 RUN apt-get install -y default-jdk
 
 # LaTeX
+RUN apt-get install -y texlive-latex-base
+RUN apt-get install -y texlive-fonts-recommended
 RUN apt-get install -y texlive-latex-extra
 RUN apt-get install -y xzdec
 RUN tlmgr init-usertree
-RUN tlmgr install helvetic
-RUN tlmgr install psnfss
 
 # PhantomJS
 RUN apt-get install -y phantomjs


### PR DESCRIPTION
This PR add building the docker image as part of Travis CI and two fixes which causes failure of building it.

`-q` or quiet flag is raised for docker build because it'll flood Travis build log and surpass the 4 MB limit, but if the docker build fail it'll display the logs if it fails.
