### PR TITLE
fixed some markdown typos

### DIFF
--- a/src/jekyll/_posts/2014/jul/2014-07-14-commands.md
+++ b/src/jekyll/_posts/2014/jul/2014-07-14-commands.md
@@ -60,9 +60,9 @@ contains a list of Github user names, who are allowed to merge into
 the branch.
 
 If you want to change the list of users or lock some other branch,
-post ``@rultor lock branch=`master`, users=`jeff,yegor256```.
+post ``@rultor lock branch=`master`, users=`jeff,yegor256` ``.
 
-To unlock, post ``@rultor unlock branch=`master```. Again, the default
+To unlock, post ``@rultor unlock branch=`master` ``. Again, the default
 branch is `master`.
 
 ## Merge


### PR DESCRIPTION
Markdown couldn't tell where the end of the `code` syntax highlighting was. Adding a spaces isn't ideal but it's essentially harmless and fixes the issue.