### PR TITLE
#1195 added Postgres configuration in Dockerfile

### DIFF
--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -106,6 +106,18 @@ RUN rm -rf /usr/lib/node_modules
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
 RUN apt-get install -y nodejs
 
+# Postgres
+RUN apt-get install -y postgresql postgresql-contrib libpq-dev
+USER postgres
+RUN    /etc/init.d/postgresql start &&\
+    psql --command "CREATE USER rultor WITH SUPERUSER PASSWORD 'rultor';" &&\
+    createdb -O rultor rultor
+RUN echo "host all  all    0.0.0.0/0  md5" >> /etc/postgresql/9.3/main/pg_hba.conf
+RUN echo "listen_addresses='*'" >> /etc/postgresql/9.3/main/postgresql.conf
+EXPOSE 5432
+USER root
+# Postgresql service has to be started using `sudo /etc/init.d/postgresql start` in .rultor.yml
+
 # Maven
 ENV MAVEN_VERSION 3.3.9
 ENV M2_HOME "/usr/local/apache-maven/apache-maven-${MAVEN_VERSION}"


### PR DESCRIPTION
Postgresql service has to be started using `sudo /etc/init.d/postgresql start` from `.rultor.yml`

I could not find a way to start the service while initializing the container. 
I searched a bit and read at few places that it is also not a good idea to use `service` command in Dockerfile.