### PR TITLE
Use longer fingerprint

### DIFF
--- a/src/main/java/com/rultor/agents/req/Decrypt.java
+++ b/src/main/java/com/rultor/agents/req/Decrypt.java
@@ -107,7 +107,7 @@ final class Decrypt {
                     SPACE,
                     "gpg",
                     this.proxy,
-                    "--verbose --recv-keys 9AF0FA4C"
+                    "--verbose --recv-keys 3FD3FA7E9AF0FA4C"
                 ).asString()
             );
             commands.add("gpg --version");


### PR DESCRIPTION
32-bit id is often unresolvable by key servers