### PR TITLE
feat(#1612): fix release script - now it can work with any branch

### DIFF
--- a/src/main/resources/com/rultor/agents/req/release.sh
+++ b/src/main/resources/com/rultor/agents/req/release.sh
@@ -38,7 +38,7 @@ git checkout "${BRANCH_NAME}"
 git tag "${tag}" -m "${tag}: tagged by rultor.com"
 git reset --hard
 git clean -fd
-git checkout master
+git checkout "${head_branch}"
 git branch -D "${BRANCH_NAME}"
 git push --all origin
 git push --tags origin

--- a/src/test/java/com/rultor/agents/req/StartsRequestTest.java
+++ b/src/test/java/com/rultor/agents/req/StartsRequestTest.java
@@ -67,7 +67,7 @@ public final class StartsRequestTest {
     /**
      * Default head_branch value.
      */
-    private static final String HEAD_BRANCH = "master";
+    private static final String HEAD_BRANCH = "main";
 
     /**
      * Temp directory.


### PR DESCRIPTION
I've fixed the `release.sh` script - now it should work with any default branch (like `master` or `main`).

Closes: #1612.