### PR TITLE
fix: use 3.8.7 maven version for mvn action

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -14,13 +14,16 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         java: [11, 17]
-        maven: [3.8.7]
+        maven: ['3.8.7']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          maven-version: ${{ matrix.maven }}
+      - uses: stCarolas/setup-maven@v.4.5
+        with:
           maven-version: ${{ matrix.maven }}
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         java: [11, 17]
+        maven: ['3.8.7']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -21,7 +21,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
-          maven-version: ${{ matrix.maven }}
       - uses: stCarolas/setup-maven@v.4.5
         with:
           maven-version: ${{ matrix.maven }}

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -14,13 +14,14 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         java: [11, 17]
-        maven: ['3.8.7']
+        maven: [3.8.7]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          maven-version: ${{ matrix.maven }}
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository


### PR DESCRIPTION
fix: use 3.8.7 maven version for mvn action
___
Update: It seems that it's impossible to specify `maven` version for `setup-java` action. You can read more about it [here](https://github.com/actions/setup-java/issues/457)
___
The actual problem with `minify` plugin that was broken after release a new maven version `3.9.0`. 

Exception log:
```java
[ERROR] Failed to execute goal com.samaxes.maven:minify-maven-plugin:1.7.6:minify (minify-js) on project rultor: Execution minify-js of goal com.samaxes.maven:minify-maven-plugin:1.7.6:minify failed: A required class was missing while executing com.samaxes.maven:minify-maven-plugin:1.7.6:minify: org/codehaus/plexus/util/DirectoryScanner
[ERROR] -----------------------------------------------------
[ERROR] realm =    plugin>com.samaxes.maven:minify-maven-plugin:1.7.6
[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
[ERROR] urls[0] = file:/Users/lombrozo/.m2/repository/com/samaxes/maven/minify-maven-plugin/1.7.6/minify-maven-plugin-1.7.6.jar
[ERROR] urls[1] = file:/Users/lombrozo/.m2/repository/com/yahoo/platform/yui/yuicompressor/2.4.8/yuicompressor-2.4.8.jar
[ERROR] urls[2] = file:/Users/lombrozo/.m2/repository/rhino/js/1.7R2/js-1.7R2.jar
[ERROR] urls[3] = file:/Users/lombrozo/.m2/repository/com/google/javascript/closure-compiler/v20161024/closure-compiler-v20161024.jar
[ERROR] urls[4] = file:/Users/lombrozo/.m2/repository/com/google/javascript/closure-compiler-externs/v20161024/closure-compiler-externs-v20161024.jar
[ERROR] urls[5] = file:/Users/lombrozo/.m2/repository/args4j/args4j/2.33/args4j-2.33.jar
[ERROR] urls[6] = file:/Users/lombrozo/.m2/repository/com/google/guava/guava/19.0/guava-19.0.jar
[ERROR] urls[7] = file:/Users/lombrozo/.m2/repository/com/google/protobuf/protobuf-java/3.0.2/protobuf-java-3.0.2.jar
[ERROR] urls[8] = file:/Users/lombrozo/.m2/repository/com/google/code/findbugs/jsr305/3.0.1/jsr305-3.0.1.jar
[ERROR] urls[9] = file:/Users/lombrozo/.m2/repository/com/google/jsinterop/jsinterop-annotations/1.0.0/jsinterop-annotations-1.0.0.jar
[ERROR] urls[10] = file:/Users/lombrozo/.m2/repository/com/google/code/gson/gson/2.8.0/gson-2.8.0.jar
[ERROR] Number of foreign imports: 1
[ERROR] import: Entry[import  from realm ClassRealm[project>com.rultor:rultor:2.0-SNAPSHOT, parent: ClassRealm[maven.api, parent: null]]]
```
Apparently, `org/codehaus/plexus/util/DirectoryScanner` was modified/removed in the new maven version.
