### PR TITLE
Replace outdated `minify-maven-plugin` with `closure-compiler-maven-plugin` 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -479,19 +479,19 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
             </goals>
             <configuration>
               <sassSourceDirectory>${basedir}/src/main/scss</sassSourceDirectory>
-              <destination>${project.build.directory}/css</destination>
+              <destination>${project.build.outputDirectory}/css</destination>
             </configuration>
           </execution>
         </executions>
       </plugin>
       <plugin>
-        <groupId>com.samaxes.maven</groupId>
-        <artifactId>minify-maven-plugin</artifactId>
-        <version>1.7.6</version>
+        <groupId>com.github.blutorange</groupId>
+        <artifactId>closure-compiler-maven-plugin</artifactId>
+        <version>2.25.0</version>
         <configuration>
-          <charset>UTF-8</charset>
-          <nosuffix>true</nosuffix>
-          <webappTargetDir>${project.build.outputDirectory}</webappTargetDir>
+          <!-- Base configuration for all executions (bundles) -->
+          <baseTargetDir>${project.build.outputDirectory}</baseTargetDir>
+          <encoding>UTF-8</encoding>
         </configuration>
         <executions>
           <execution>
@@ -500,27 +500,19 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
               <goal>minify</goal>
             </goals>
             <configuration>
-              <webappSourceDir>${project.basedir}/src/main</webappSourceDir>
-              <jsSourceIncludes>
-                <include>*.js</include>
-              </jsSourceIncludes>
-              <jsEngine>CLOSURE</jsEngine>
+              <baseSourceDir>${project.basedir}/src/main</baseSourceDir>
+              <includes>
+                <include>**/*.js</include>
+              </includes>
               <skipMerge>true</skipMerge>
+              <closureEmitUseStrict>false</closureEmitUseStrict>
               <skipMinify>false</skipMinify>
-            </configuration>
-          </execution>
-          <execution>
-            <id>minify-css</id>
-            <goals>
-              <goal>minify</goal>
-            </goals>
-            <configuration>
-              <webappSourceDir>${project.build.directory}</webappSourceDir>
-              <cssSourceDir>css</cssSourceDir>
-              <cssSourceIncludes>
-                <include>*.css</include>
-              </cssSourceIncludes>
-              <skipMerge>false</skipMerge>
+              <outputFilename>
+                #{path}/#{basename}.#{extension}
+              </outputFilename>
+              <closureLanguageOut>
+                NO_TRANSPILE
+              </closureLanguageOut>
             </configuration>
           </execution>
         </executions>

--- a/src/main/resources/com/rultor/web/daemon/head.html
+++ b/src/main/resources/com/rultor/web/daemon/head.html
@@ -5,7 +5,8 @@
     <meta name="description" content="rultor.com build log"/>
     <meta name="keywords" content="continuous integration, continuous delivery, DevOps"/>
     <meta name="author" content="rultor.com"/>
-    <link rel="stylesheet" type="text/css" media="all" href="/css/style.css"/>
+    <link rel="stylesheet" type="text/css" media="all" href="/css/main.css"/>
+    <link rel="stylesheet" type="text/css" media="all" href="/css/siblings.css"/>
     <link rel="stylesheet" type="text/css" media="all" href="//doc.rultor.com/css/layout.css"/>
     <link rel="icon" type="image/gif" href="//doc.rultor.com/favicon.ico"/>
     <title>rultor.com</title>

--- a/src/main/resources/com/rultor/web/error.html.vm
+++ b/src/main/resources/com/rultor/web/error.html.vm
@@ -32,6 +32,7 @@
         <title>Internal application error</title>
         <link href="//doc.rultor.com/css/layout.css?${rev}" rel="stylesheet" type="text/css"/>
         <link href="/css/style.css?${rev}" rel="stylesheet" type="text/css"/>
+        <link href="/css/style.css?${rev}" rel="stylesheet" type="text/css"/>
         <link rel="icon" type="image/gif" href="//doc.rultor.com/favicon.ico"/>
     </head>
     <body>

--- a/src/main/resources/com/rultor/web/error.html.vm
+++ b/src/main/resources/com/rultor/web/error.html.vm
@@ -31,8 +31,8 @@
     <head>
         <title>Internal application error</title>
         <link href="//doc.rultor.com/css/layout.css?${rev}" rel="stylesheet" type="text/css"/>
-        <link href="/css/style.css?${rev}" rel="stylesheet" type="text/css"/>
-        <link href="/css/style.css?${rev}" rel="stylesheet" type="text/css"/>
+        <link href="/css/main.css?${rev}" rel="stylesheet" type="text/css"/>
+        <link href="/css/siblings.css?${rev}" rel="stylesheet" type="text/css"/>
         <link rel="icon" type="image/gif" href="//doc.rultor.com/favicon.ico"/>
     </head>
     <body>

--- a/src/main/xsl/layout.xsl
+++ b/src/main/xsl/layout.xsl
@@ -37,7 +37,8 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
         <meta name="keywords" content="continuous integration, continuous delivery, DevOps"/>
         <meta name="author" content="rultor.com"/>
         <meta property="twitter:account_id" content="4503599630178231"/>
-        <link rel="stylesheet" type="text/css" media="all" href="/css/style.css?{version/revision}"/>
+        <link rel="stylesheet" type="text/css" media="all" href="/css/main.css?{version/revision}"/>
+        <link rel="stylesheet" type="text/css" media="all" href="/css/siblings.css?{version/revision}"/>
         <link rel="stylesheet" type="text/css" media="all" href="//doc.rultor.com/css/layout.css?{version/revision}"/>
         <link rel="icon" type="image/gif" href="//doc.rultor.com/favicon.ico?{version/revision}"/>
         <script type="text/javascript" src="//code.jquery.com/jquery-2.1.1-rc1.min.js">

--- a/src/test/java/com/rultor/web/TkAppTest.java
+++ b/src/test/java/com/rultor/web/TkAppTest.java
@@ -150,6 +150,13 @@ public final class TkAppTest {
             new Toggles.InFile()
         );
         Assertions.assertEquals(
+            new StringBuilder()
+                .append("$(document).ready(function(){var a=$(\"#pulse\");")
+                .append("window.setInterval(function(){a.find(\"img\")")
+                .append(".attr(\"src\",a.attr(\"data-href\")+\"?\"")
+                .append("+Date.now())},1E3)});")
+                .append("\n")
+                .toString(),
             new TextOf(
                 new RsPrint(
                     take.act(
@@ -160,12 +167,7 @@ public final class TkAppTest {
                         )
                     )
                 ).body()
-            ).asString(),
-            new StringBuilder()
-                .append("$(document).ready(function(){var a=$(\"#pulse\");")
-                .append("window.setInterval(function(){a.find(\"img\")")
-                .append(".attr(\"src\",a.attr(\"data-href\")+\"?\"")
-                .append("+Date.now())},1E3)});").toString()
+            ).asString()
         );
     }
 

--- a/src/test/java/com/rultor/web/TkHomeITCase.java
+++ b/src/test/java/com/rultor/web/TkHomeITCase.java
@@ -118,7 +118,8 @@ public final class TkHomeITCase {
             "/robots.txt",
             "/xsl/layout.xsl",
             "/xsl/home.xsl",
-            "/css/style.css",
+            "/css/main.css",
+            "/css/siblings.css",
         };
         final Request request = new JdkRequest(TkHomeITCase.HOME);
         for (final String page : pages) {


### PR DESCRIPTION
The proper solution for https://github.com/yegor256/rultor/pull/1627, that will work with new `maven 3.9.0` version.
1. Removed old `minify` plugin
2. Added new plugin `closure-compiler-maven-plugin` - the only branch from `minify` plugin. Here is the [link](https://github.com/blutorange/closure-compiler-maven-plugin).
3. The only problem - `closure-compiler-maven-plugin` works **ONLY** with `.js` files. By that reason we have to use `.css` files without _minification_ (but we can add an issue to solve that in the future).