### PR TITLE
Use latest maven version for GitHub actions

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -14,16 +14,12 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         java: [11, 17]
-        maven: ['3.8.7']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      - uses: stCarolas/setup-maven@v.4.5
-        with:
-          maven-version: ${{ matrix.maven }}
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository


### PR DESCRIPTION
Since we solved all problems with the new Maven `3.9.0` version, we don't have to specify the particular maven version for GitHub actions.