### PR TITLE
feat(#1661): print first line of a GitHub comment

### DIFF
--- a/src/main/java/com/rultor/agents/github/qtn/QnSafe.java
+++ b/src/main/java/com/rultor/agents/github/qtn/QnSafe.java
@@ -54,6 +54,12 @@ import lombok.ToString;
 public final class QnSafe implements Question {
 
     /**
+     * Default error message format.
+     */
+    private static final String DEFAULT_FORMAT =
+        "We failed, sorry, try again:\n\n```\n%[exception]s\n```";
+
+    /**
      * Original question.
      */
     private final transient Question origin;
@@ -68,7 +74,8 @@ public final class QnSafe implements Question {
 
     @Override
     public Req understand(final Comment.Smart comment,
-        final URI home) throws IOException {
+        final URI home
+    ) throws IOException {
         Req req;
         if (QnSafe.valid(comment)) {
             try {
@@ -76,8 +83,9 @@ public final class QnSafe implements Question {
                 // @checkstyle IllegalCatchCheck (1 line)
             } catch (final Throwable ex) {
                 new Answer(comment).post(
-                    false, Logger.format(
-                        "We failed, sorry, try again:\n\n```%[exception]s```",
+                    false,
+                    Logger.format(
+                        QnSafe.DEFAULT_FORMAT,
                         ex
                     )
                 );
@@ -98,7 +106,7 @@ public final class QnSafe implements Question {
         boolean valid = true;
         try {
             comment.issue().json();
-        // @checkstyle IllegalCatchCheck (1 line)
+            // @checkstyle IllegalCatchCheck (1 line)
         } catch (final Throwable ex) {
             valid = false;
             Logger.warn(QnSafe.class, "%[exception]s", ex);

--- a/src/test/java/com/rultor/agents/github/qtn/QnSafeTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnSafeTest.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2009-2022 Yegor Bugayenko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the rultor.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.rultor.agents.github.qtn;
+
+import com.jcabi.github.Comment;
+import com.jcabi.github.Issue;
+import com.jcabi.github.mock.MkGithub;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Date;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link QnSafe}.
+ *
+ * @author Volodya Lombrozo (volodya.lombrozo@gmail.com)
+ * @version $Id$
+ * @since 1.76
+ */
+class QnSafeTest {
+
+    /**
+     * QnSafe can understand a comment even if some exception is thrown.
+     * It's worth noting that the exception text has to be included after ```
+     * and EMPTY LINE, otherwise, the first line of the exception message
+     * will be treated as language specification and invisible in GitHub
+     * message.
+     * Compare
+     * <p>{@code
+     *     ```java.lang.IllegalArgumentException: Illegal argument exception
+     * }</p>
+     * with
+     * <p>{@code
+     *     ```
+     *     java.lang.IllegalArgumentException: Illegal argument exception
+     * }</p>
+     * The first example will print empty message to GitHub comment because it
+     * will be treated as unknown language:
+     * 'java.lang.IllegalArgumentException: Illegal argument exception'
+     *
+     * @throws URISyntaxException if URI is invalid
+     * @throws IOException if I/O fails.
+     */
+    @Test
+    public void understandsWithThrowable()
+        throws URISyntaxException, IOException {
+        final Issue issue = new MkGithub().randomRepo()
+            .issues()
+            .create("", "");
+        final Comment post = issue.comments().post("Hello, world!");
+        new QnSafe(
+            (comment, home) -> {
+                throw new IllegalArgumentException(
+                    "Illegal argument exception",
+                    new IOException("Artificial cause")
+                );
+            }
+        ).understand(
+            new Comment.Smart(post),
+            new URI("http://www.example.com")
+        );
+        MatcherAssert.assertThat(
+            issue.comments().iterate(new Date(0)),
+            Matchers.iterableWithSize(2)
+        );
+        final String body = new Comment.Smart(issue.comments().get(2)).body();
+        MatcherAssert.assertThat(
+            body, Matchers.allOf(
+                Matchers.containsString("We failed, sorry"),
+                Matchers.containsString("```\n")
+            )
+        );
+    }
+}


### PR DESCRIPTION
Print first line of the error message.

Closes: #1661 