### PR TITLE
feat(#1758): fix bug with release.pre=false

### DIFF
--- a/src/main/java/com/rultor/agents/Agents.java
+++ b/src/main/java/com/rultor/agents/Agents.java
@@ -117,7 +117,7 @@ import org.cactoos.text.UncheckedText;
  */
 @Immutable
 @ToString
-@EqualsAndHashCode(of = { "github", "sttc" })
+@EqualsAndHashCode(of = {"github", "sttc"})
 @SuppressWarnings("PMD.ExcessiveImports")
 public final class Agents {
 
@@ -288,7 +288,7 @@ public final class Agents {
                         )
                     )
                 ),
-                new CommentsTag(this.github),
+                new CommentsTag(this.github, profile),
                 new ReleaseBinaries(this.github, profile),
                 new Dephantomizes(this.github),
                 new Reports(this.github),

--- a/src/main/java/com/rultor/agents/github/CommentsTag.java
+++ b/src/main/java/com/rultor/agents/github/CommentsTag.java
@@ -93,19 +93,19 @@ public final class CommentsTag extends AbstractAgent {
 
     /**
      * Constructor.
-     * @param github Github client
-     * @param profile Profile
+     * @param ghub Github client
+     * @param config Profile
      */
     public CommentsTag(
-        final Github github,
-        final Profile profile
+        final Github ghub,
+        final Profile config
     ) {
         super(
             "/talk/wire[github-repo and github-issue]",
             "/talk/request[@id and type='release' and success='true']"
         );
-        this.github = github;
-        this.profile = profile;
+        this.github = ghub;
+        this.profile = config;
     }
 
     @Override
@@ -154,16 +154,20 @@ public final class CommentsTag extends AbstractAgent {
 
     /**
      * Check if release is prerelease.
+     * True if profile does not specify release.pre=false.
      * @return True if prerelease, false otherwise.
      */
     private boolean isPrerelease() {
         try {
+            final boolean result;
             final List<String> xpath = this.profile.read()
                 .xpath("/p/entry[@key='release']/entry[@key='pre']/text()");
             if (xpath.isEmpty()) {
-                return true;
+                result = true;
+            } else {
+                result = "true".equals(xpath.get(0).trim());
             }
-            return "true".equals(xpath.get(0).trim());
+            return result;
         } catch (final IOException exception) {
             throw new IllegalStateException(
                 String.format(

--- a/src/main/java/com/rultor/agents/github/CommentsTag.java
+++ b/src/main/java/com/rultor/agents/github/CommentsTag.java
@@ -163,7 +163,7 @@ public final class CommentsTag extends AbstractAgent {
             if (xpath.isEmpty()) {
                 return true;
             }
-            return "true".equals(xpath.get(0));
+            return "true".equals(xpath.get(0).trim());
         } catch (final IOException exception) {
             throw new IllegalStateException(
                 String.format(

--- a/src/main/java/com/rultor/spi/Profile.java
+++ b/src/main/java/com/rultor/spi/Profile.java
@@ -191,15 +191,18 @@ public interface Profile {
          */
         public Fixed() {
             this(
-                new XMLDocument(
-                    String.join(
-                        "",
-                        "<p><entry key='merge'/>",
-                        "<entry key='release'/>",
-                        "<entry key='deploy'/></p>"
-                    )
-                )
+                "<p><entry key='merge'/>",
+                "<entry key='release'/>",
+                "<entry key='deploy'/></p>"
             );
+        }
+
+        /**
+         * Ctor.
+         * @param xml Xml lines
+         */
+        public Fixed(String... xml) {
+            this(new XMLDocument(String.join("", xml)));
         }
 
         /**

--- a/src/main/java/com/rultor/spi/Profile.java
+++ b/src/main/java/com/rultor/spi/Profile.java
@@ -199,10 +199,10 @@ public interface Profile {
 
         /**
          * Ctor.
-         * @param xml Xml lines
+         * @param lines Xml lines
          */
-        public Fixed(String... xml) {
-            this(new XMLDocument(String.join("", xml)));
+        public Fixed(final String... lines) {
+            this(new XMLDocument(String.join("", lines)));
         }
 
         /**

--- a/src/test/java/com/rultor/agents/github/CommentsTagTest.java
+++ b/src/test/java/com/rultor/agents/github/CommentsTagTest.java
@@ -34,7 +34,6 @@ import com.jcabi.github.Release;
 import com.jcabi.github.Releases;
 import com.jcabi.github.Repo;
 import com.jcabi.github.mock.MkGithub;
-import com.jcabi.xml.XMLDocument;
 import com.rultor.spi.Agent;
 import com.rultor.spi.Profile;
 import com.rultor.spi.Talk;
@@ -169,7 +168,7 @@ public final class CommentsTagTest {
 
     /**
      * CommentsTag can create latest release if profile specify 'pre: false'.
-     * @throws Exception In case of error.
+     * @throws IOException In case of error.
      */
     @Test
     public void createsLatestRelease() throws IOException {
@@ -182,17 +181,18 @@ public final class CommentsTagTest {
         final Agent agent = new CommentsTag(
             repo.github(),
             new Profile.Fixed(
-                "<p><entry key='release'><entry key='pre'>false</entry></entry></p>"
+                "<p>",
+                "<entry key='release'>",
+                "<entry key='pre'>",
+                "false",
+                "</entry></entry></p>"
             )
         );
         final String tag = "v1.1.latest";
         final Talk talk = CommentsTagTest.talk(issue, tag);
         agent.execute(talk);
         MatcherAssert.assertThat(
-            String.format(
-                "We expect that release with tag '%s' is the latest final release (not a pre-release)",
-                tag
-            ),
+            "We expect latest release to be created (not pre)",
             new Release.Smart(
                 new Releases.Smart(repo.releases()).find(tag)
             ).prerelease(),
@@ -201,7 +201,8 @@ public final class CommentsTagTest {
     }
 
     /**
-     * CommentsTag can create pre-release by default if profile specify anything.
+     * CommentsTag can create pre-release by default.
+     * Check the default behaviour if profile specifies anything.
      * @throws IOException In case of error.
      */
     @Test
@@ -217,10 +218,7 @@ public final class CommentsTagTest {
         final Talk talk = CommentsTagTest.talk(issue, tag);
         agent.execute(talk);
         MatcherAssert.assertThat(
-            String.format(
-                "We expect that release with tag '%s' is the pre-release by default if profile does not specify 'pre: false'",
-                tag
-            ),
+            "We expect pre-release to be created by default",
             new Release.Smart(
                 new Releases.Smart(repo.releases()).find(tag)
             ).prerelease(),

--- a/src/test/java/com/rultor/agents/github/CommentsTagTest.java
+++ b/src/test/java/com/rultor/agents/github/CommentsTagTest.java
@@ -34,7 +34,9 @@ import com.jcabi.github.Release;
 import com.jcabi.github.Releases;
 import com.jcabi.github.Repo;
 import com.jcabi.github.mock.MkGithub;
+import com.jcabi.xml.XMLDocument;
 import com.rultor.spi.Agent;
+import com.rultor.spi.Profile;
 import com.rultor.spi.Talk;
 import java.io.IOException;
 import org.hamcrest.MatcherAssert;
@@ -177,7 +179,12 @@ public final class CommentsTagTest {
                 "Latest Release",
                 "This issue is created for latest release"
             );
-        final Agent agent = new CommentsTag(repo.github());
+        final Agent agent = new CommentsTag(
+            repo.github(),
+            new Profile.Fixed(
+                "<p><entry key='release'><entry key='pre'>false</entry></entry></p>"
+            )
+        );
         final String tag = "v1.1.latest";
         final Talk talk = CommentsTagTest.talk(issue, tag);
         agent.execute(talk);
@@ -193,6 +200,10 @@ public final class CommentsTagTest {
         );
     }
 
+    /**
+     * CommentsTag can create pre-release by default if profile specify anything.
+     * @throws IOException In case of error.
+     */
     @Test
     public void createsPreReleaseByDefault() throws IOException {
         final Repo repo = new MkGithub().randomRepo();

--- a/src/test/java/com/rultor/agents/github/CommentsTagTest.java
+++ b/src/test/java/com/rultor/agents/github/CommentsTagTest.java
@@ -166,6 +166,58 @@ public final class CommentsTagTest {
     }
 
     /**
+     * CommentsTag can create latest release if profile specify 'pre: false'.
+     * @throws Exception In case of error.
+     */
+    @Test
+    public void createsLatestRelease() throws IOException {
+        final Repo repo = new MkGithub().randomRepo();
+        final Issue issue = repo.issues()
+            .create(
+                "Latest Release",
+                "This issue is created for latest release"
+            );
+        final Agent agent = new CommentsTag(repo.github());
+        final String tag = "v1.1.latest";
+        final Talk talk = CommentsTagTest.talk(issue, tag);
+        agent.execute(talk);
+        MatcherAssert.assertThat(
+            String.format(
+                "We expect that release with tag '%s' is the latest final release (not a pre-release)",
+                tag
+            ),
+            new Release.Smart(
+                new Releases.Smart(repo.releases()).find(tag)
+            ).prerelease(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    public void createsPreReleaseByDefault() throws IOException {
+        final Repo repo = new MkGithub().randomRepo();
+        final Issue issue = repo.issues()
+            .create(
+                "Pre Release",
+                "This issue is created for pre release"
+            );
+        final Agent agent = new CommentsTag(repo.github());
+        final String tag = "v1.1.pre-release";
+        final Talk talk = CommentsTagTest.talk(issue, tag);
+        agent.execute(talk);
+        MatcherAssert.assertThat(
+            String.format(
+                "We expect that release with tag '%s' is the pre-release by default if profile does not specify 'pre: false'",
+                tag
+            ),
+            new Release.Smart(
+                new Releases.Smart(repo.releases()).find(tag)
+            ).prerelease(),
+            Matchers.is(true)
+        );
+    }
+
+    /**
      * Make a talk with this tag.
      * @param issue The issue
      * @param tag The tag


### PR DESCRIPTION
Rultor used to ignore `release.pre:false` flag during a release. In this PR it was fixed.

Closes: #1758.
____
History:
- feat(#1758): add tests that show what we want to get
- feat(#1758): implement profile check before release
- feat(#1758): fix all the qulice suggestions
