### PR TITLE
[#1876] RegisterShell saves to PfShell resolved IP address

### DIFF
--- a/src/main/java/com/rultor/agents/shells/PfShell.java
+++ b/src/main/java/com/rultor/agents/shells/PfShell.java
@@ -54,7 +54,7 @@ public final class PfShell {
     private final transient Profile profile;
 
     /**
-     * Host name.
+     * Host name or IP address.
      */
     private final transient String addr;
 
@@ -76,7 +76,7 @@ public final class PfShell {
     /**
      * Constructor.
      * @param prof Profile
-     * @param host Default IP address
+     * @param host Default IP address or Host name
      * @param port Default Port of server
      * @param login Default Login
      * @param key Default Private SSH key

--- a/src/main/java/com/rultor/agents/shells/RegistersShell.java
+++ b/src/main/java/com/rultor/agents/shells/RegistersShell.java
@@ -35,6 +35,7 @@ import com.jcabi.xml.XML;
 import com.rultor.agents.AbstractAgent;
 import com.rultor.spi.Profile;
 import java.io.IOException;
+import java.net.UnknownHostException;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.xembly.Directive;
@@ -59,20 +60,17 @@ public final class RegistersShell extends AbstractAgent {
     /**
      * Constructor.
      * @param profile Profile
-     * @param host Default IP address
+     * @param host Default IP address or host name
      * @param port Default Port of server
      * @param user Default Login
      * @param key Default Private SSH key
+     * @throws UnknownHostException in case of host is not resolved
      * @checkstyle ParameterNumberCheck (6 lines)
      */
     public RegistersShell(final Profile profile, final String host,
-        final int port, final String user, final String key) {
+        final int port, final String user, final String key)
+        throws UnknownHostException {
         super("/talk[daemon and not(shell)]");
-        if (host.isEmpty()) {
-            throw new IllegalArgumentException(
-                "Host is mandatory"
-            );
-        }
         if (user.isEmpty()) {
             throw new IllegalArgumentException(
                 "User name is mandatory"
@@ -83,7 +81,13 @@ public final class RegistersShell extends AbstractAgent {
                 "SSH key is mandatory"
             );
         }
-        this.shell = new PfShell(profile, host, port, user, key);
+        this.shell = new PfShell(
+            profile,
+            new SmartHost(host).ip(),
+            port,
+            user,
+            key
+        );
     }
 
     @Override

--- a/src/main/java/com/rultor/agents/shells/SmartHost.java
+++ b/src/main/java/com/rultor/agents/shells/SmartHost.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2009-2024 Yegor Bugayenko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the rultor.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.rultor.agents.shells;
+
+import com.jcabi.aspects.Immutable;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * Host.
+ *
+ * @since 1.77.0
+ */
+@Immutable
+@ToString
+@EqualsAndHashCode(of = { "host" })
+@SuppressWarnings({"PMD.ShortMethodName",
+    "PMD.ConstructorOnlyInitializesOrCallOtherConstructors"})
+final class SmartHost {
+    /**
+     * Server address.
+     */
+    private final transient InetAddress host;
+
+    /**
+     * Ctor.
+     * @param address Host name or IP address
+     * @throws UnknownHostException in case of address is not resolved
+     */
+    SmartHost(final String address) throws UnknownHostException {
+        if (address.isEmpty()) {
+            throw new IllegalArgumentException(
+                "Host is mandatory"
+            );
+        }
+        this.host = InetAddress.getByName(address);
+    }
+
+    /**
+     * Host's IP.
+     *
+     * @return Ip address
+     * @checkstyle MethodNameCheck (3 lines)
+     */
+    public String ip() {
+        return this.host.getHostAddress();
+    }
+}

--- a/src/test/java/com/rultor/agents/shells/RegistersShellTest.java
+++ b/src/test/java/com/rultor/agents/shells/RegistersShellTest.java
@@ -46,10 +46,11 @@ import org.xembly.Directives;
  *
  * @since 1.0
  */
+@SuppressWarnings("PMD.AvoidUsingHardCodedIP")
 final class RegistersShellTest {
 
     /**
-     * RegistersShell can register a shell.
+     * RegistersShell can register a shell with hostname.
      * @throws Exception In case of error.
      */
     @Test
@@ -72,7 +73,7 @@ final class RegistersShellTest {
                     ).asString()
                 )
             ),
-            "localhost", 22, "rultor", "def-key"
+            "127.0.0.1", 22, "rultor", "def-key"
         );
         final Talk talk = new Talk.InFile();
         talk.modify(
@@ -94,6 +95,36 @@ final class RegistersShellTest {
     }
 
     /**
+     * RegistersShell can register shell by IP.
+     * @throws Exception In case of error.
+     */
+    @Test
+    void registerShellWithIP() {
+        final String host = "192.168.5.49";
+        final int port = 221;
+        final String key = "";
+        final String login = "john";
+        Assertions.assertDoesNotThrow(
+            () -> new RegistersShell(
+                new Profile.Fixed(
+                    new XMLDocument(
+                        new Joined(
+                            " ",
+                            "<p><entry key='ssh'>",
+                            String.format("<entry key='host'>%s</entry>", host),
+                            String.format("<entry key='port'>%d</entry>", port),
+                            String.format("<entry key='key'>%s</entry>", key),
+                            String.format("<entry key='login'>%s</entry>", login),
+                            "</entry></p>"
+                        ).asString()
+                    )
+                ),
+                host, 22, "rultor", "def-key"
+            )
+        );
+    }
+
+    /**
      * RegistersShell can handle broken profile.
      * @throws Exception In case of error.
      */
@@ -102,12 +133,11 @@ final class RegistersShellTest {
         final Profile profile = Mockito.mock(Profile.class);
         Mockito.doThrow(new Profile.ConfigException("")).when(profile).read();
         final Agent agent = new RegistersShell(
-            profile, "test-host", 1, "test-user", "test-key"
+            profile, "localhost", 1, "test-user", "test-key"
         );
         final Talk talk = new Talk.InFile();
         Assertions.assertDoesNotThrow(
             () -> agent.execute(talk)
         );
     }
-
 }


### PR DESCRIPTION
- resolved ip address is saved from RegisterShell to PfShell
- UnknownHostException will be thrown in case of unresolved or invalid host name
- StartsDockerDaemon without changes (it also use PfShell)