### PR TITLE
[#1701] Get pre value from the comment (if presented)

### DIFF
--- a/src/main/java/com/rultor/agents/github/CommentsTag.java
+++ b/src/main/java/com/rultor/agents/github/CommentsTag.java
@@ -135,7 +135,7 @@ public final class CommentsTag extends AbstractAgent {
                 rels.create(tag.trim())
             );
             rel.name(CommentsTag.title(req, issue));
-            rel.prerelease(this.isPrerelease());
+            rel.prerelease(this.isPrerelease(req));
             rel.body(
                 String.format(
                     // @checkstyle LineLength (1 line)
@@ -153,17 +153,24 @@ public final class CommentsTag extends AbstractAgent {
     /**
      * Check if release is prerelease.
      * True if profile does not specify release.pre=false.
+     * @param req Comment's xml
      * @return True if prerelease, false otherwise.
      */
-    private boolean isPrerelease() {
+    private boolean isPrerelease(final XML req) {
         try {
             final boolean result;
-            final List<String> xpath = this.profile.read()
-                .xpath("/p/entry[@key='release']/entry[@key='pre']/text()");
-            if (xpath.isEmpty()) {
-                result = true;
+            final List<String> comment = req
+                .xpath("args/arg[@name='pre']/text()");
+            if (comment.isEmpty()) {
+                final List<String> xpath = this.profile.read()
+                    .xpath("/p/entry[@key='release']/entry[@key='pre']/text()");
+                if (xpath.isEmpty()) {
+                    result = true;
+                } else {
+                    result = "true".equals(xpath.get(0).trim());
+                }
             } else {
-                result = "true".equals(xpath.get(0).trim());
+                result = "true".equals(comment.get(0).trim());
             }
             return result;
         } catch (final IOException exception) {

--- a/src/test/java/com/rultor/agents/github/CommentsTagTest.java
+++ b/src/test/java/com/rultor/agents/github/CommentsTagTest.java
@@ -182,6 +182,47 @@ final class CommentsTagTest {
                 "<p>",
                 "<entry key='release'>",
                 "<entry key='pre'>",
+                "true",
+                "</entry></entry></p>"
+            )
+        );
+        final String tag = "v1.1.latest";
+        final Talk talk = CommentsTagTest.talk(issue, tag);
+        talk.modify(
+            new Directives().xpath("/talk/request/args")
+                .add("arg")
+                .attr("name", "pre")
+                .set("false")
+        );
+        agent.execute(talk);
+        MatcherAssert.assertThat(
+            "We expect latest release to be created (not pre)",
+            new Release.Smart(
+                new Releases.Smart(repo.releases()).find(tag)
+            ).prerelease(),
+            Matchers.is(false)
+        );
+    }
+
+    /**
+     * CommentsTag can create latest release if profile specify 'pre: true',
+     * but 'pre: false' is written in the comment.
+     * @throws IOException In case of error.
+     */
+    @Test
+    void createsLatestReleaseFromTalk() throws IOException {
+        final Repo repo = new MkGithub().randomRepo();
+        final Issue issue = repo.issues()
+            .create(
+                "Latest Release",
+                "This issue is created for latest release"
+            );
+        final Agent agent = new CommentsTag(
+            repo.github(),
+            new Profile.Fixed(
+                "<p>",
+                "<entry key='release'>",
+                "<entry key='pre'>",
                 "false",
                 "</entry></entry></p>"
             )

--- a/src/test/java/com/rultor/agents/github/ReleaseBinariesTest.java
+++ b/src/test/java/com/rultor/agents/github/ReleaseBinariesTest.java
@@ -79,7 +79,6 @@ final class ReleaseBinariesTest {
             dir.getAbsolutePath(), "repo", target, name.replace("${tag}", tag)
         );
         bin.mkdirs();
-        new SecureRandom();
         final byte[] content = SecureRandom.getSeed(100);
         new LengthOf(new TeeInput(content, bin)).value();
         final Talk talk = ReleaseBinariesTest


### PR DESCRIPTION
Get the value for release - pre from the comment if presented 

Fix #1701 