### PR TITLE
Update to qulice 0.22.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -828,7 +828,7 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.22.1</version>
+            <version>0.22.2</version>
             <configuration>
               <excludes combine.children="append">
                 <exclude>checkstyle:/src/main/js/.*</exclude>

--- a/src/main/java/com/rultor/agents/daemons/ArchivesDaemon.java
+++ b/src/main/java/com/rultor/agents/daemons/ArchivesDaemon.java
@@ -46,7 +46,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Date;
 import java.util.logging.Level;
-import javax.ws.rs.core.MediaType;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.apache.commons.io.FileUtils;
@@ -132,7 +131,7 @@ public final class ArchivesDaemon extends AbstractAgent {
      */
     private URI upload(final File file, final String hash) throws IOException {
         final ObjectMetadata meta = new ObjectMetadata();
-        meta.setContentType(MediaType.TEXT_PLAIN);
+        meta.setContentType("text/plain");
         meta.setContentEncoding(StandardCharsets.UTF_8.name());
         meta.setContentLength(file.length());
         final String key = String.format("%tY/%1$tm/%s.txt", new Date(), hash);

--- a/src/main/java/com/rultor/agents/github/CommitsLog.java
+++ b/src/main/java/com/rultor/agents/github/CommitsLog.java
@@ -84,7 +84,7 @@ final class CommitsLog {
      * @return Release body text.
      * @throws IOException In case of problem communicating with git.
      */
-    @SuppressWarnings("PMD.UseConcurrentHashMap")
+    @SuppressWarnings({"PMD.UseConcurrentHashMap", "PMD.UseDiamondOperator"})
     public String build(final Date prev, final Date current)
         throws IOException {
         final DateFormat format = new SimpleDateFormat(

--- a/src/main/java/com/rultor/agents/shells/PfShell.java
+++ b/src/main/java/com/rultor/agents/shells/PfShell.java
@@ -33,7 +33,6 @@ import com.jcabi.aspects.Immutable;
 import com.jcabi.ssh.Ssh;
 import com.rultor.spi.Profile;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import lombok.EqualsAndHashCode;
@@ -151,8 +150,7 @@ public final class PfShell {
         if (path.isEmpty()) {
             key = this.pvt;
         } else {
-            final InputStream asset = this.profile.assets().get(path);
-            if (asset == null) {
+            if (this.profile.assets().get(path) == null) {
                 throw new Profile.ConfigException(
                     String.format("Private SSH key not found at %s", path)
                 );

--- a/src/main/java/com/rultor/web/TkSiblings.java
+++ b/src/main/java/com/rultor/web/TkSiblings.java
@@ -163,7 +163,6 @@ final class TkSiblings implements TkRegex {
             dirs.append(TkSiblings.log(xml, log));
         }
         return dirs.up().add("name").set(talk.name()).up()
-            // @checkstyle MultipleStringLiteralsCheck (1 line)
             .add("href").set(xml.xpath("/talk/wire/href/text()").get(0)).up()
             .add("updated").set(Long.toString(talk.updated().getTime())).up()
             .add("timeago").set(new PrettyTime().format(talk.updated())).up()

--- a/src/test/java/com/rultor/TimeTest.java
+++ b/src/test/java/com/rultor/TimeTest.java
@@ -30,7 +30,6 @@
 package com.rultor;
 
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
@@ -54,7 +53,8 @@ final class TimeTest {
     void canParseValidTime() {
         final String date = "2005-10-08T15:48:39";
         Assertions.assertDoesNotThrow(
-            () -> new Time(date)
+            () -> new Time(date),
+            "Time should be able to create from date-time string"
         );
     }
 
@@ -71,7 +71,8 @@ final class TimeTest {
     void exceptionParseInvalidTime(final String date) {
         Assertions.assertThrows(
             IllegalStateException.class,
-            () -> new Time(date)
+            () -> new Time(date),
+            "Exception is expected for invalid date time string"
         );
     }
 
@@ -80,12 +81,13 @@ final class TimeTest {
      */
     @Test
     void isoValidFormat() {
-        final Date date = Calendar.getInstance().getTime();
+        final Date date = new Date();
         final SimpleDateFormat format =
             new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
         format.setTimeZone(TimeZone.getTimeZone("GMT"));
         final Time time =  new Time(date);
         MatcherAssert.assertThat(
+            "ISO value should be for the GMT timezone",
             time.iso(),
             Matchers.equalTo(format.format(date))
         );
@@ -99,6 +101,7 @@ final class TimeTest {
         final Date date = new Date();
         final Time time = new Time();
         MatcherAssert.assertThat(
+            "Time without parameters should get current time",
             time.msec(),
             Matchers.allOf(
                 Matchers.greaterThanOrEqualTo(date.getTime()),
@@ -115,6 +118,7 @@ final class TimeTest {
         final Date date = new Date();
         final Time time = new Time(date);
         MatcherAssert.assertThat(
+            "Time should get date from the parameter",
             time.msec(),
             Matchers.equalTo(date.getTime())
         );
@@ -128,6 +132,7 @@ final class TimeTest {
         final Date date = new Date();
         final Time time = new Time(date.getTime());
         MatcherAssert.assertThat(
+            "Time should get msec value from parameter",
             time.msec(),
             Matchers.equalTo(date.getTime())
         );

--- a/src/test/java/com/rultor/agents/IndexesRequestsTest.java
+++ b/src/test/java/com/rultor/agents/IndexesRequestsTest.java
@@ -64,6 +64,7 @@ final class IndexesRequestsTest {
         );
         new IndexesRequests().execute(talks);
         MatcherAssert.assertThat(
+            "Talk should be reindexed (1 based)",
             talks.get(name).read(),
             XhtmlMatchers.hasXPaths("/talk/request[@index='1']")
         );
@@ -94,14 +95,14 @@ final class IndexesRequestsTest {
         );
         new IndexesRequests().execute(talks);
         MatcherAssert.assertThat(
+            "Index value should be started from log records max",
             talks.get(name).read(),
             XhtmlMatchers.hasXPaths("/talk/request[@index='3']")
         );
     }
 
     /**
-     * IndexesRequests should retrieve index from sibling
-     * (the test is skipped, more information in #733).
+     * IndexesRequests should retrieve index from sibling.
      * @throws Exception In case of error.
      */
     @Test
@@ -141,6 +142,7 @@ final class IndexesRequestsTest {
         );
         new IndexesRequests().execute(talks);
         MatcherAssert.assertThat(
+            "Index value should be started from log records max",
             talks.get(third).read(),
             XhtmlMatchers.hasXPaths("/talk/request[@index='5']")
         );
@@ -163,6 +165,7 @@ final class IndexesRequestsTest {
         );
         new IndexesRequests().execute(talks);
         MatcherAssert.assertThat(
+            "Request tag should not be created if does not exist",
             talks.get(name).read(),
             Matchers.not(
                 XhtmlMatchers.hasXPaths("/talk/request")

--- a/src/test/java/com/rultor/agents/MailsTest.java
+++ b/src/test/java/com/rultor/agents/MailsTest.java
@@ -72,6 +72,7 @@ final class MailsTest {
         Mockito.verify(postman).send(captor.capture());
         final Envelope envelope = captor.getValue();
         MatcherAssert.assertThat(
+            "Mail text should contain some data",
             envelope.unwrap().getContent().toString(),
             Matchers.allOf(
                 Matchers.containsString("See #456, release log:"),
@@ -83,6 +84,7 @@ final class MailsTest {
             )
         );
         MatcherAssert.assertThat(
+            "Mail subject should be about release",
             envelope.unwrap().getSubject(),
             Matchers.equalTo("user/repo v2.0 released!")
         );

--- a/src/test/java/com/rultor/agents/PublishesTest.java
+++ b/src/test/java/com/rultor/agents/PublishesTest.java
@@ -63,6 +63,7 @@ final class PublishesTest {
         );
         agent.execute(talk);
         MatcherAssert.assertThat(
+            "public attribute should be added",
             talk.read(),
             XhtmlMatchers.hasXPath("/talk[@public='true']")
         );
@@ -84,6 +85,7 @@ final class PublishesTest {
         );
         agent.execute(talk);
         MatcherAssert.assertThat(
+            "public attribute should be kept false",
             talk.read(),
             XhtmlMatchers.hasXPath("/talk[@public='false']")
         );

--- a/src/test/java/com/rultor/agents/daemons/ArchivesDaemonITCase.java
+++ b/src/test/java/com/rultor/agents/daemons/ArchivesDaemonITCase.java
@@ -94,6 +94,7 @@ final class ArchivesDaemonITCase {
             );
             agent.execute(talk);
             MatcherAssert.assertThat(
+                "archive tag should be created with bucket name",
                 talk.read(),
                 XhtmlMatchers.hasXPaths(
                     "/talk[not(daemon)]",

--- a/src/test/java/com/rultor/agents/daemons/DismountDaemonTest.java
+++ b/src/test/java/com/rultor/agents/daemons/DismountDaemonTest.java
@@ -71,6 +71,7 @@ final class DismountDaemonTest {
         final Agent agent = new DismountDaemon();
         agent.execute(talk);
         MatcherAssert.assertThat(
+            "Daemon should be stopped for not found host",
             talk.read(),
             XhtmlMatchers.hasXPaths(
                 "/talk/daemon/ended",
@@ -104,6 +105,7 @@ final class DismountDaemonTest {
         final Agent agent = new DismountDaemon();
         agent.execute(talk);
         MatcherAssert.assertThat(
+            "Daemon should not be ended if younger then 10 days",
             talk.read(),
             XhtmlMatchers.hasXPaths("/talk/daemon[not(ended)]")
         );

--- a/src/test/java/com/rultor/agents/daemons/EndsDaemonITCase.java
+++ b/src/test/java/com/rultor/agents/daemons/EndsDaemonITCase.java
@@ -40,6 +40,7 @@ import com.rultor.spi.Profile;
 import com.rultor.spi.Talk;
 import java.io.IOException;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.hamcrest.core.StringContains;
 import org.hamcrest.core.StringEndsWith;
 import org.junit.jupiter.api.Assumptions;
@@ -78,6 +79,7 @@ final class EndsDaemonITCase {
             final Agent agent = new EndsDaemon();
             agent.execute(talk);
             MatcherAssert.assertThat(
+                "Rultor prefix should be moved to highlights",
                 talk.read(),
                 XhtmlMatchers.hasXPaths(
                     "/talk/daemon/highlights",
@@ -105,6 +107,7 @@ final class EndsDaemonITCase {
             final Agent agent = new EndsDaemon();
             agent.execute(talk);
             MatcherAssert.assertThat(
+                "Status code should be placed to daemon/code",
                 talk.read(),
                 XhtmlMatchers.hasXPath("/talk/daemon[code='123']")
             );
@@ -133,6 +136,7 @@ final class EndsDaemonITCase {
             final Agent agent = new EndsDaemon();
             agent.execute(talk);
             MatcherAssert.assertThat(
+                "Exception message should be placed in tail text",
                 talk.read(),
                 XhtmlMatchers.hasXPaths(
                     "/talk/daemon[code='154']",
@@ -165,14 +169,14 @@ final class EndsDaemonITCase {
                     final String dir = talk.read()
                         .xpath("/talk/daemon/dir/text()").get(0);
                     MatcherAssert.assertThat(
+                        "Deprecation message should be printed",
                         dir,
-                        StringContains.containsString(
-                            "#### Deprecation Notice ####"
+                        Matchers.allOf(
+                            StringContains.containsString(
+                                "#### Deprecation Notice ####"
+                            ),
+                            StringEndsWith.endsWith("##############")
                         )
-                    );
-                    MatcherAssert.assertThat(
-                        dir,
-                        StringEndsWith.endsWith("##############")
                     );
                 }
             }
@@ -200,7 +204,6 @@ final class EndsDaemonITCase {
         talk.modify(
             new Directives().xpath("/talk")
                 .add("daemon")
-                // @checkstyle MultipleStringLiterals (1 line)
                 .attr("id", "abcd")
                 .add("title").set("merge").up()
                 .add("script").set("ls").up()

--- a/src/test/java/com/rultor/agents/daemons/KillsDaemonTest.java
+++ b/src/test/java/com/rultor/agents/daemons/KillsDaemonTest.java
@@ -62,6 +62,7 @@ final class KillsDaemonTest {
         final Agent agent = new KillsDaemon();
         agent.execute(talk);
         MatcherAssert.assertThat(
+            "KillsDaemon stops daemon older then 1h by default",
             talk.read(),
             XhtmlMatchers.hasXPath("/talk/daemon")
         );

--- a/src/test/java/com/rultor/agents/daemons/StartsDaemonITCase.java
+++ b/src/test/java/com/rultor/agents/daemons/StartsDaemonITCase.java
@@ -79,6 +79,7 @@ final class StartsDaemonITCase {
         ) {
             final Talk talk = StartsDaemonITCase.talk(start);
             MatcherAssert.assertThat(
+                "started tag should be added with start time",
                 talk.read(),
                 XhtmlMatchers.hasXPaths(
                     "/talk/daemon[started and dir]",
@@ -95,6 +96,7 @@ final class StartsDaemonITCase {
                 baos, baos
             );
             MatcherAssert.assertThat(
+                "Start script should be send to daemon",
                 baos.toString(StandardCharsets.UTF_8.name()),
                 Matchers.allOf(
                     Matchers.containsString("+ set -o pipefail"),
@@ -104,7 +106,9 @@ final class StartsDaemonITCase {
                 )
             );
             MatcherAssert.assertThat(
-                new File(dir, "status").exists(), Matchers.is(false)
+                "status file should not be created",
+                new File(dir, "status").exists(),
+                Matchers.is(false)
             );
         }
     }
@@ -136,7 +140,11 @@ final class StartsDaemonITCase {
             } else {
                 matcher = Matchers.not(StringStartsWith.startsWith(notice));
             }
-            MatcherAssert.assertThat(dir, matcher);
+            MatcherAssert.assertThat(
+                "Deprecation message in case of default image should be printed",
+                dir,
+                matcher
+            );
         }
     }
 

--- a/src/test/java/com/rultor/agents/daemons/TailITCase.java
+++ b/src/test/java/com/rultor/agents/daemons/TailITCase.java
@@ -36,7 +36,7 @@ import com.rultor.Time;
 import com.rultor.agents.shells.PfShell;
 import com.rultor.spi.Profile;
 import com.rultor.spi.Talk;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -89,9 +89,10 @@ final class TailITCase {
                     .add("key").set(sshd.key()).up().up()
             );
             MatcherAssert.assertThat(
+                "SSH output should be in the Tail",
                 IOUtils.toString(
                     new Tail(talk.read(), hash).read(),
-                    Charset.forName("UTF-8")
+                    StandardCharsets.UTF_8
                 ),
                 Matchers.is(String.format("%sê\n", clean))
             );

--- a/src/test/java/com/rultor/agents/docker/StartsDockerDaemonTest.java
+++ b/src/test/java/com/rultor/agents/docker/StartsDockerDaemonTest.java
@@ -60,22 +60,24 @@ final class StartsDockerDaemonTest {
         ) {
             final PfShell shell = start.shell();
             MatcherAssert.assertThat(
+                "Should login as root",
                 shell.login(),
                 Matchers.is("root")
             );
             final String key = shell.key();
             MatcherAssert.assertThat(
+                "Should be RSA key",
                 key,
-                Matchers.startsWith("-----BEGIN RSA PRIVATE KEY-----")
-            );
-            MatcherAssert.assertThat(
-                key,
-                Matchers.endsWith("-----END RSA PRIVATE KEY-----")
+                Matchers.allOf(
+                    Matchers.startsWith("-----BEGIN RSA PRIVATE KEY-----"),
+                    Matchers.endsWith("-----END RSA PRIVATE KEY-----")
+                )
             );
             final Shell.Plain ssh = new Shell.Plain(
                 new Ssh(shell.host(), shell.port(), shell.login(), shell.key())
             );
             MatcherAssert.assertThat(
+                "Key should be placed in /root/.ssh/id_rsa",
                 ssh.exec("cat /root/.ssh/id_rsa"),
                 Matchers.containsString(key)
             );

--- a/src/test/java/com/rultor/agents/github/AnswerTest.java
+++ b/src/test/java/com/rultor/agents/github/AnswerTest.java
@@ -59,6 +59,7 @@ final class AnswerTest {
             true, "hey you\u0000"
         );
         MatcherAssert.assertThat(
+            "Answer with source comment should be posted",
             new Comment.Smart(issue.comments().get(2)).body(),
             Matchers.containsString("> hey, do it\n\n")
         );
@@ -82,6 +83,7 @@ final class AnswerTest {
             answer.post(true, "oops");
         }
         MatcherAssert.assertThat(
+            "Only 5 answers should be posted",
             new ListOf<>(issue.comments().iterate(new Date(0L))).size(),
             Matchers.is(6)
         );

--- a/src/test/java/com/rultor/agents/github/ClosePullRequestTest.java
+++ b/src/test/java/com/rultor/agents/github/ClosePullRequestTest.java
@@ -78,9 +78,11 @@ final class ClosePullRequestTest {
         new ClosePullRequest(profile, repo.github()).execute(talk);
         final Issue.Smart smart = new Issue.Smart(issue);
         MatcherAssert.assertThat(
+            "PR should be closed",
             smart.state(), Matchers.is("closed")
         );
         MatcherAssert.assertThat(
+            "Rebase message should be added",
             new Comment.Smart(smart.comments().get(1)).body(),
             Matchers.containsString(
                 new Joined(
@@ -119,9 +121,11 @@ final class ClosePullRequestTest {
         new ClosePullRequest(profile, repo.github()).execute(talk);
         final Issue.Smart smart = new Issue.Smart(issue);
         MatcherAssert.assertThat(
+            "Issue should be open",
             smart.state(), Matchers.is("open")
         );
         MatcherAssert.assertThat(
+            "No comments should be added",
             smart.comments().iterate(new Date(0L)),
             Matchers.is(Matchers.emptyIterable())
         );

--- a/src/test/java/com/rultor/agents/github/CommentsTagTest.java
+++ b/src/test/java/com/rultor/agents/github/CommentsTagTest.java
@@ -66,6 +66,7 @@ final class CommentsTagTest {
         final Talk talk = CommentsTagTest.talk(issue, tag);
         agent.execute(talk);
         MatcherAssert.assertThat(
+            "Release should be created",
             new Releases.Smart(repo.releases()).exists(tag),
             Matchers.is(true)
         );
@@ -85,6 +86,7 @@ final class CommentsTagTest {
         final Talk talk = CommentsTagTest.talk(issue, tag);
         agent.execute(talk);
         MatcherAssert.assertThat(
+            "Release should be created",
             new Releases.Smart(repo.releases()).exists(tag),
             Matchers.is(true)
         );
@@ -107,6 +109,7 @@ final class CommentsTagTest {
         );
         final String body = smart.body();
         MatcherAssert.assertThat(
+            "Release message should be posted",
             body,
             Matchers.allOf(
                 Matchers.containsString("Released by Rultor"),
@@ -129,6 +132,7 @@ final class CommentsTagTest {
         final String tag = "v1.6";
         agent.execute(CommentsTagTest.talk(issue, tag));
         MatcherAssert.assertThat(
+            "Issue should be in release title",
             new Release.Smart(
                 new Releases.Smart(repo.releases()).find(tag)
             ).name(),
@@ -156,6 +160,7 @@ final class CommentsTagTest {
         );
         agent.execute(talk);
         MatcherAssert.assertThat(
+            "Release title should be from the command",
             new Release.Smart(
                 new Releases.Smart(repo.releases()).find(tag)
             ).name(),

--- a/src/test/java/com/rultor/agents/github/CommitsLogTest.java
+++ b/src/test/java/com/rultor/agents/github/CommitsLogTest.java
@@ -69,6 +69,7 @@ final class CommitsLogTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(commits).when(repo).commits();
         MatcherAssert.assertThat(
+            "Message should be shorter",
             new CommitsLog(repo).build(new Date(), new Date()),
             Matchers.equalTo(
                 " * a1b2c3 by @jeff: hi\u20ac this is a very long commit..."
@@ -92,6 +93,7 @@ final class CommitsLogTest {
         final Repo repo = Mockito.mock(Repo.class);
         Mockito.doReturn(commits).when(repo).commits();
         MatcherAssert.assertThat(
+            "Only 20 commits should be mentioned directly",
             new CommitsLog(repo).build(new Date(), new Date()),
             Matchers.containsString("* and 80 more..")
         );

--- a/src/test/java/com/rultor/agents/github/DephantomizesTest.java
+++ b/src/test/java/com/rultor/agents/github/DephantomizesTest.java
@@ -56,6 +56,7 @@ final class DephantomizesTest {
         final Talk talk = DephantomizesTest.talk(repo, 0);
         new Dephantomizes(github).execute(talk);
         MatcherAssert.assertThat(
+            "Request and wire should be removed",
             talk.read(),
             XhtmlMatchers.hasXPath("/talk[not(request) and not(wire)]")
         );
@@ -73,6 +74,7 @@ final class DephantomizesTest {
         final Talk talk = DephantomizesTest.talk(repo, 1);
         new Dephantomizes(github).execute(talk);
         MatcherAssert.assertThat(
+            "Request and wire should not be removed",
             talk.read(),
             XhtmlMatchers.hasXPath("/talk[request and wire]")
         );

--- a/src/test/java/com/rultor/agents/github/DropsTalkTest.java
+++ b/src/test/java/com/rultor/agents/github/DropsTalkTest.java
@@ -57,6 +57,7 @@ final class DropsTalkTest {
         final Agent agent = new DropsTalk();
         agent.execute(talk);
         MatcherAssert.assertThat(
+            "Talk should be not with later after DropsTalk",
             talk.read(),
             XhtmlMatchers.hasXPaths("/talk[@later='false']")
         );

--- a/src/test/java/com/rultor/agents/github/FirstCommentTest.java
+++ b/src/test/java/com/rultor/agents/github/FirstCommentTest.java
@@ -54,6 +54,7 @@ final class FirstCommentTest {
             new FirstComment(new Issue.Smart(issue))
         );
         MatcherAssert.assertThat(
+            "Author should be added",
             cmt.author().login(),
             Matchers.equalTo("jeff")
         );

--- a/src/test/java/com/rultor/agents/github/IssueUrlTest.java
+++ b/src/test/java/com/rultor/agents/github/IssueUrlTest.java
@@ -45,6 +45,7 @@ final class IssueUrlTest {
         final IssueUrl issue =
             new IssueUrl("https://api.github.com/repos/USER/REPO/pulls/5086");
         MatcherAssert.assertThat(
+            "It is a valid url for github PR",
             issue.valid(),
             Matchers.is(true)
         );
@@ -56,6 +57,7 @@ final class IssueUrlTest {
             "https://api.github.com/repos/USER/REPO/pulls/5386/files#r123"
         );
         MatcherAssert.assertThat(
+            "it is a valid url for file is github PR",
             issue.valid(),
             Matchers.is(true)
         );
@@ -67,6 +69,7 @@ final class IssueUrlTest {
             "https://api.github.com/repos/USER/REPO/issues/5182"
         );
         MatcherAssert.assertThat(
+            "It is a valid url for github issue",
             issue.valid(),
             Matchers.is(true)
         );
@@ -78,6 +81,7 @@ final class IssueUrlTest {
             "https://api.github.com/repos/USER/REPO/commit/2a1f8"
         );
         MatcherAssert.assertThat(
+            "It is a valid url for github commit",
             issue.valid(),
             Matchers.is(false)
         );
@@ -89,6 +93,7 @@ final class IssueUrlTest {
             "https://api.github.com/repos/USER/REPO/pulls/5186"
         );
         MatcherAssert.assertThat(
+            "Id should be parsed from PR url",
             issue.uid(),
             Matchers.is(5186)
         );
@@ -100,6 +105,7 @@ final class IssueUrlTest {
             "https://api.github.com/repos/USER/REPO/issues/5782"
         );
         MatcherAssert.assertThat(
+            "Id should be parsed from issue url",
             issue.uid(),
             Matchers.is(5782)
         );
@@ -111,6 +117,7 @@ final class IssueUrlTest {
             "https://api.github.com/repos/USER/REPO/pulls/5886/files#r123"
         );
         MatcherAssert.assertThat(
+            "PR id should be parsed from file url",
             issue.uid(),
             Matchers.is(5886)
         );
@@ -123,7 +130,8 @@ final class IssueUrlTest {
         );
         Assertions.assertThrows(
             IllegalStateException.class,
-            issue::uid
+            issue::uid,
+            "Id should not be parsed from commit url"
         );
     }
 }

--- a/src/test/java/com/rultor/agents/github/ReportsTest.java
+++ b/src/test/java/com/rultor/agents/github/ReportsTest.java
@@ -39,6 +39,7 @@ import com.rultor.spi.Talk;
 import java.io.IOException;
 import java.util.ResourceBundle;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.xembly.Directives;
 
@@ -78,6 +79,7 @@ final class ReportsTest {
         final Agent agent = new Reports(repo.github());
         agent.execute(talk);
         MatcherAssert.assertThat(
+            "Request should not be created",
             talk.read(),
             XhtmlMatchers.hasXPath(ReportsTest.XPATH)
         );
@@ -98,6 +100,7 @@ final class ReportsTest {
         final Agent agent = new Reports(repo.github());
         agent.execute(talk);
         MatcherAssert.assertThat(
+            "Request should not be created",
             talk.read(),
             XhtmlMatchers.hasXPath(ReportsTest.XPATH)
         );
@@ -105,7 +108,8 @@ final class ReportsTest {
             "Comment contains warning about stop request",
             repo.issues().get(1).comments().get(1).json().getString(
                 "body"
-            ).equals(
+            ),
+            Matchers.is(
                 String.format(
                     "> %s\n\n@%s %s %s",
                     stop,

--- a/src/test/java/com/rultor/agents/github/StarsTest.java
+++ b/src/test/java/com/rultor/agents/github/StarsTest.java
@@ -55,6 +55,7 @@ final class StarsTest {
         final Talk talk = this.talk(repo);
         new Stars(github).execute(talk);
         MatcherAssert.assertThat(
+            "Star should be added to the repo",
             repo.stars().starred(),
             Matchers.is(true)
         );
@@ -72,6 +73,7 @@ final class StarsTest {
         repo.stars().star();
         new Stars(github).execute(talk);
         MatcherAssert.assertThat(
+            "Star should be kept if already stared",
             repo.stars().starred(),
             Matchers.is(true)
         );

--- a/src/test/java/com/rultor/agents/github/StartsTalksTest.java
+++ b/src/test/java/com/rultor/agents/github/StartsTalksTest.java
@@ -60,6 +60,7 @@ final class StartsTalksTest {
         final Talks talks = new Talks.InDir();
         agent.execute(talks);
         MatcherAssert.assertThat(
+            "Active talk should not be created",
             talks.active(),
             Matchers.not(Matchers.emptyIterable())
         );

--- a/src/test/java/com/rultor/agents/github/UnderstandsTest.java
+++ b/src/test/java/com/rultor/agents/github/UnderstandsTest.java
@@ -91,6 +91,7 @@ final class UnderstandsTest {
         agent.execute(talk);
         agent.execute(talk);
         MatcherAssert.assertThat(
+            "Deploy request should be created",
             talk.read(),
             XhtmlMatchers.hasXPaths(
                 "/talk/wire[github-seen='2']",
@@ -122,6 +123,7 @@ final class UnderstandsTest {
         final Talk talk = UnderstandsTest.talk(issue);
         agent.execute(talk);
         MatcherAssert.assertThat(
+            "Request should not be created",
             talk.read(),
             XhtmlMatchers.hasXPaths("/talk[not(request)]")
         );
@@ -142,6 +144,7 @@ final class UnderstandsTest {
         final Talk talk = UnderstandsTest.talk(issue);
         agent.execute(talk);
         MatcherAssert.assertThat(
+            "Reply comment should be created for hello",
             issue.comments().iterate(new Date(0L)),
             Matchers.iterableWithSize(1)
         );
@@ -173,10 +176,12 @@ final class UnderstandsTest {
         ).execute(UnderstandsTest.talk(pull));
         final Comments comments = repo.issues().get(1).comments();
         MatcherAssert.assertThat(
+            "Reply comment should be created",
             comments.iterate(new Date(0)),
             Matchers.iterableWithSize(1)
         );
         MatcherAssert.assertThat(
+            "Message about not possible merge should be created",
             new Comment.Smart(comments.get(1)).body(),
             Matchers.containsString("Can't merge")
         );

--- a/src/test/java/com/rultor/agents/github/qtn/QnAloneTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnAloneTest.java
@@ -63,6 +63,7 @@ final class QnAloneTest {
         final Talk talk = new Talk.InFile();
         final Locks locks = new MkSttc().locks();
         MatcherAssert.assertThat(
+            "Deploy request should be created",
             new Xembler(
                 new Directives().add("request").append(
                     new QnAlone(talk, locks, new QnDeploy()).understand(

--- a/src/test/java/com/rultor/agents/github/qtn/QnAskedByTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnAskedByTest.java
@@ -73,6 +73,7 @@ final class QnAskedByTest {
         qab.understand(comment, new URI("http://localhost"));
         final Comment.Smart reply = new Comment.Smart(issue.comments().get(2));
         MatcherAssert.assertThat(
+            "Rultor should not be included in the message",
             reply.body(),
             Matchers.not(
                 Matchers.containsString("@rultor")

--- a/src/test/java/com/rultor/agents/github/qtn/QnByArchitectTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnByArchitectTest.java
@@ -42,7 +42,6 @@ import java.util.Date;
 import java.util.Locale;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -74,8 +73,16 @@ final class QnByArchitectTest {
         ).understand(comment, home);
         Mockito.verify(question, Mockito.never()).understand(comment, home);
         MatcherAssert.assertThat(
+            "Two comments should be posted",
             issue.comments().iterate(new Date(0L)),
             Matchers.iterableWithSize(2)
+        );
+        MatcherAssert.assertThat(
+            "Confirmation request comment should be posted",
+            new Comment.Smart(issue.comments().get(2)).body(),
+            Matchers.containsString(
+                "Thanks for your request; @johnny please confirm this"
+            )
         );
     }
 
@@ -113,7 +120,6 @@ final class QnByArchitectTest {
      * pull request made by an architect.
      * @throws Exception In case of error.
      */
-    @Disabled
     @Test
     void acceptsIfMergeArchitectPull() throws Exception {
         final Repo repo = new MkGithub().randomRepo();

--- a/src/test/java/com/rultor/agents/github/qtn/QnConfigTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnConfigTest.java
@@ -58,12 +58,14 @@ final class QnConfigTest {
         issue.comments().post("hello");
         final Profile profile = new Profile.Fixed();
         MatcherAssert.assertThat(
+            "hello command should be recognized",
             new QnConfig(profile).understand(
                 new Comment.Smart(issue.comments().get(1)), new URI("#")
             ),
             Matchers.is(Req.DONE)
         );
         MatcherAssert.assertThat(
+            "Xml view of rultor.yml should be added to the comment",
             new Comment.Smart(issue.comments().get(2)).body(),
             Matchers.containsString("</p>")
         );

--- a/src/test/java/com/rultor/agents/github/qtn/QnDeployTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnDeployTest.java
@@ -58,6 +58,7 @@ final class QnDeployTest {
         final Issue issue = repo.issues().create("", "");
         issue.comments().post("deploy");
         MatcherAssert.assertThat(
+            "Deploy request should be created",
             new Xembler(
                 new Directives().add("request").append(
                     new QnDeploy().understand(

--- a/src/test/java/com/rultor/agents/github/qtn/QnFirstOfTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnFirstOfTest.java
@@ -58,6 +58,7 @@ final class QnFirstOfTest {
         final Issue issue = repo.issues().create("", "");
         final Comment comment = issue.comments().post("deploy");
         MatcherAssert.assertThat(
+            "First not empty question should be taken",
             new QnFirstOf(
                 Arrays.asList(
                     Question.EMPTY,

--- a/src/test/java/com/rultor/agents/github/qtn/QnGithubIssueTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnGithubIssueTest.java
@@ -74,6 +74,7 @@ final class QnGithubIssueTest {
             }
         };
         MatcherAssert.assertThat(
+            "request should save issue data",
             new StrictXML(
                 new XMLDocument(
                     new Xembler(

--- a/src/test/java/com/rultor/agents/github/qtn/QnHelloTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnHelloTest.java
@@ -56,12 +56,14 @@ final class QnHelloTest {
         final Issue issue = repo.issues().create("", "");
         issue.comments().post("hello");
         MatcherAssert.assertThat(
+            "Request should be marked as done",
             new QnHello().understand(
                 new Comment.Smart(issue.comments().get(1)), new URI("#")
             ),
             Matchers.is(Req.DONE)
         );
         MatcherAssert.assertThat(
+            "Hello message should be posted",
             new Comment.Smart(issue.comments().get(2)).body(),
             Matchers.containsString("Have fun :)")
         );

--- a/src/test/java/com/rultor/agents/github/qtn/QnIamLostTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnIamLostTest.java
@@ -56,6 +56,7 @@ final class QnIamLostTest {
         final Issue issue = repo.issues().create("", "");
         issue.comments().post("boom");
         MatcherAssert.assertThat(
+            "Command should be marked as done",
             new QnIamLost().understand(
                 new Comment.Smart(issue.comments().get(1)),
                 new URI("#")
@@ -63,6 +64,7 @@ final class QnIamLostTest {
             Matchers.is(Req.DONE)
         );
         MatcherAssert.assertThat(
+            "Comment about not found command should be posted",
             new Comment.Smart(issue.comments().get(2)).body(),
             Matchers.containsString("don't understand you")
         );

--- a/src/test/java/com/rultor/agents/github/qtn/QnIfCollaboratorTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnIfCollaboratorTest.java
@@ -58,6 +58,7 @@ final class QnIfCollaboratorTest {
         final Issue issue = repo.issues().create("", "");
         issue.comments().post("deploy");
         MatcherAssert.assertThat(
+            "Empty request should be created",
             new Xembler(
                 new Directives().add("request").append(
                     new QnIfCollaborator(new QnDeploy()).understand(

--- a/src/test/java/com/rultor/agents/github/qtn/QnIfContainsTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnIfContainsTest.java
@@ -59,6 +59,7 @@ final class QnIfContainsTest {
             new Comment.Smart(issue.comments().get(1)), new URI("#")
         ).dirs();
         MatcherAssert.assertThat(
+            "No message should be posted",
             issue.comments().iterate(new Date(0L)),
             Matchers.iterableWithSize(1)
         );
@@ -77,6 +78,7 @@ final class QnIfContainsTest {
             new Comment.Smart(issue.comments().get(1)), new URI("#test")
         ).dirs();
         MatcherAssert.assertThat(
+            "Hello message should be posted",
             issue.comments().iterate(new Date(0L)),
             Matchers.iterableWithSize(2)
         );
@@ -95,6 +97,7 @@ final class QnIfContainsTest {
             new Comment.Smart(issue.comments().get(1)), new URI("#")
         ).dirs();
         MatcherAssert.assertThat(
+            "No comments should be posted",
             issue.comments().iterate(new Date(0L)),
             Matchers.iterableWithSize(1)
         );

--- a/src/test/java/com/rultor/agents/github/qtn/QnIfUnlockedTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnIfUnlockedTest.java
@@ -32,11 +32,11 @@ package com.rultor.agents.github.qtn;
 import com.jcabi.github.Comment;
 import com.jcabi.github.Issue;
 import com.jcabi.github.Repo;
+import com.jcabi.github.mock.MkBranches;
 import com.jcabi.github.mock.MkGithub;
 import com.jcabi.matchers.XhtmlMatchers;
 import java.net.URI;
 import org.hamcrest.MatcherAssert;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.xembly.Directives;
 import org.xembly.Xembler;
@@ -54,14 +54,17 @@ final class QnIfUnlockedTest {
      * @throws Exception In case of error.
      */
     @Test
-    @Disabled
     void buildsRequest() throws Exception {
         final Repo repo = new MkGithub().randomRepo();
+        final MkBranches branches = (MkBranches) repo.branches();
+        branches.create("head", "dfgsadf4");
+        branches.create("base", "retygdy6");
         final Issue issue = repo.issues().get(
             repo.pulls().create("", "head", "base").number()
         );
         issue.comments().post("merge");
         MatcherAssert.assertThat(
+            "Merge request should be created if not locked",
             new Xembler(
                 new Directives().add("request").append(
                     new QnIfUnlocked(new QnMerge()).understand(
@@ -69,7 +72,7 @@ final class QnIfUnlockedTest {
                     ).dirs()
                 )
             ).xml(),
-            XhtmlMatchers.hasXPath("/request[not(type)]")
+            XhtmlMatchers.hasXPath("/request/type[text()='merge']")
         );
     }
 

--- a/src/test/java/com/rultor/agents/github/qtn/QnLastOfTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnLastOfTest.java
@@ -58,6 +58,7 @@ final class QnLastOfTest {
         final Issue issue = repo.issues().create("", "");
         final Comment comment = issue.comments().post("deploy");
         MatcherAssert.assertThat(
+            "Deploy request should be created",
             new QnLastOf(
                 Arrays.asList(
                     Question.EMPTY,

--- a/src/test/java/com/rultor/agents/github/qtn/QnLockTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnLockTest.java
@@ -56,12 +56,14 @@ final class QnLockTest {
         final Issue issue = repo.issues().create("", "");
         issue.comments().post("lock users=`@test1, test2`");
         MatcherAssert.assertThat(
+            "Command should be marked as done",
             new QnLock().understand(
                 new Comment.Smart(issue.comments().get(1)), new URI("#")
             ),
             Matchers.is(Req.DONE)
         );
         MatcherAssert.assertThat(
+            "Message about action should be posted",
             new Comment.Smart(issue.comments().get(2)).body(),
             Matchers.allOf(
                 Matchers.containsString(

--- a/src/test/java/com/rultor/agents/github/qtn/QnMergeTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnMergeTest.java
@@ -110,6 +110,7 @@ final class QnMergeTest {
     void buildsRequest() throws Exception {
         final String request = new Xembler(this.mergeRequest()).xml();
         MatcherAssert.assertThat(
+            "Merge request should be created",
             request,
             Matchers.allOf(
                 XhtmlMatchers.hasXPath("/request/type[text()='merge']"),
@@ -122,10 +123,12 @@ final class QnMergeTest {
             )
         );
         MatcherAssert.assertThat(
+            "Merge comment should be initiator",
             new Comment.Smart(this.comments.get(1)).body(),
             Matchers.is(QnMergeTest.COMMAND)
         );
         MatcherAssert.assertThat(
+            "Comment about staring merge should be posted",
             new Comment.Smart(this.comments.get(2)).body(),
             Matchers.containsString(
                 String.format(
@@ -150,10 +153,12 @@ final class QnMergeTest {
         checks.create(Check.Status.IN_PROGRESS, Check.Conclusion.SUCCESS);
         this.mergeRequest();
         MatcherAssert.assertThat(
+            "Merge comment should be initiator",
             new Comment.Smart(this.comments.get(1)).body(),
             Matchers.is(QnMergeTest.COMMAND)
         );
         MatcherAssert.assertThat(
+            "Merge should be stopped if checks are not successful",
             new Comment.Smart(this.comments.get(2)).body(),
             Matchers.containsString(
                 QnMergeTest.PHRASES.getString("QnMerge.checks-are-failed")
@@ -174,10 +179,12 @@ final class QnMergeTest {
         checks.create(Check.Status.COMPLETED, Check.Conclusion.SUCCESS);
         this.mergeRequest();
         MatcherAssert.assertThat(
+            "Merge comment should be initiator",
             new Comment.Smart(this.comments.get(1)).body(),
             Matchers.is(QnMergeTest.COMMAND)
         );
         MatcherAssert.assertThat(
+            "Merge start info comment should be posted",
             new Comment.Smart(this.comments.get(2)).body(),
             Matchers.containsString(
                 String.format(
@@ -217,10 +224,7 @@ final class QnMergeTest {
         );
         this.mergeRequest();
         MatcherAssert.assertThat(
-            new Comment.Smart(this.comments.get(1)).body(),
-            Matchers.is(QnMergeTest.COMMAND)
-        );
-        MatcherAssert.assertThat(
+            "Comment should be posted about affected system file",
             new Comment.Smart(this.comments.get(2)).body(),
             Matchers.containsString(
                 QnMergeTest.PHRASES.getString(

--- a/src/test/java/com/rultor/agents/github/qtn/QnParametrizedTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnParametrizedTest.java
@@ -77,6 +77,7 @@ final class QnParametrizedTest {
             }
         };
         MatcherAssert.assertThat(
+            "Parameters should be saved to the request",
             new Xembler(
                 new Directives().add("request").append(
                     new QnParametrized(origin).understand(
@@ -104,6 +105,7 @@ final class QnParametrizedTest {
         final Issue issue = repo.issues().create("", "");
         issue.comments().post("hey");
         MatcherAssert.assertThat(
+            "No dirs should be added to the empty command",
             new QnParametrized(Question.EMPTY).understand(
                 new Comment.Smart(issue.comments().get(1)), new URI("#1")
             ).dirs(),
@@ -121,6 +123,7 @@ final class QnParametrizedTest {
         final Issue issue = repo.issues().create("", "");
         issue.comments().post("hey you");
         MatcherAssert.assertThat(
+            "Empty request should be in case of empty question",
             new QnParametrized(Question.EMPTY).understand(
                 new Comment.Smart(issue.comments().get(1)), new URI("#2")
             ),
@@ -144,6 +147,7 @@ final class QnParametrizedTest {
             }
         };
         MatcherAssert.assertThat(
+            "Later request should be in the result",
             new QnParametrized(question).understand(
                 new Comment.Smart(issue.comments().get(1)), new URI("#2")
             ),

--- a/src/test/java/com/rultor/agents/github/qtn/QnReferredToTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnReferredToTest.java
@@ -58,12 +58,14 @@ final class QnReferredToTest {
     @Test
     void buildsRequest() throws Exception {
         MatcherAssert.assertThat(
+            "deploy request should be created",
             this.xemblerXml("  @xx deploy"),
-            XhtmlMatchers.hasXPath("/request/type")
+            XhtmlMatchers.hasXPath("/request/type[text()='deploy']")
         );
         MatcherAssert.assertThat(
+            "deploy request should be created",
             this.xemblerXml("  @xx, deploy"),
-            XhtmlMatchers.hasXPath("/request/type")
+            XhtmlMatchers.hasXPath("/request/type[text()='deploy']")
         );
     }
 
@@ -75,12 +77,14 @@ final class QnReferredToTest {
     void recognizesCommaAsDelimiter() throws Exception {
         final String login = "xx";
         MatcherAssert.assertThat(
+            "deploy command should be recognized",
             this.reqFromComment(
                 String.format("hello @%s, deploy", login), login
             ),
             Matchers.is(Req.DONE)
         );
         MatcherAssert.assertThat(
+            "deploy command should be recognized",
             this.reqFromComment(
                 String.format("hello ,@%s deploy", login), login
             ),
@@ -97,12 +101,14 @@ final class QnReferredToTest {
     void recognizesInvalidBoundary() throws Exception {
         final String login = "xx";
         MatcherAssert.assertThat(
+            "Comment should be ignored without mention",
             this.reqFromComment(
                 String.format("hello @%sx deploy", login), login
             ),
             Matchers.is(Req.EMPTY)
         );
         MatcherAssert.assertThat(
+            "Comment should be ignored without mention",
             this.reqFromComment(
                 String.format("hello x@%s deploy", login), login
             ),
@@ -121,12 +127,14 @@ final class QnReferredToTest {
         final String login = "xx";
         issue.comments().post(String.format("hello @%s deploy", login));
         MatcherAssert.assertThat(
+            "Deploy command should be recognized, if mentioned",
             new QnReferredTo(login, new QnDeploy()).understand(
                 new Comment.Smart(issue.comments().get(1)), new URI("#")
             ),
             Matchers.is(Req.DONE)
         );
         MatcherAssert.assertThat(
+            "Answer comment should be posted with instruction",
             new Comment.Smart(issue.comments().get(2)).body(),
             Matchers.containsString(
                 new Joined(

--- a/src/test/java/com/rultor/agents/github/qtn/QnReleaseTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnReleaseTest.java
@@ -60,6 +60,7 @@ final class QnReleaseTest {
         final Issue issue = repo.issues().create("", "");
         issue.comments().post("release");
         MatcherAssert.assertThat(
+            "Release request should be created",
             new Xembler(
                 new Directives().add("request").append(
                     new QnRelease().understand(
@@ -86,8 +87,9 @@ final class QnReleaseTest {
         final Repo repo = new MkGithub().randomRepo();
         final Issue issue = repo.issues().create("", "");
         repo.releases().create("1.5");
-        issue.comments().post("release `1.7`");
+        issue.comments().post("release, title `1.7`");
         MatcherAssert.assertThat(
+            "Release request should be created",
             new Xembler(
                 new Directives().add("request").append(
                     new QnRelease().understand(
@@ -115,12 +117,14 @@ final class QnReleaseTest {
         repo.releases().create("1.7");
         issue.comments().post("release `1.6`");
         MatcherAssert.assertThat(
+            "Empty request should be created",
             new QnRelease().understand(
                 new Comment.Smart(issue.comments().get(1)), new URI("#")
             ),
             Matchers.is(Req.EMPTY)
         );
         MatcherAssert.assertThat(
+            " Comment about existing release should be posted",
             new Comment.Smart(issue.comments().get(2)).body(),
             Matchers.containsString("There is already a release `1.7`")
         );
@@ -136,6 +140,7 @@ final class QnReleaseTest {
         final Issue issue = repo.issues().create("", "");
         issue.comments().post("release `1.8`, title `Version 1.8.0`");
         MatcherAssert.assertThat(
+            "Request should be created",
             new Xembler(
                 new Directives().add("request").append(
                     new QnRelease().understand(

--- a/src/test/java/com/rultor/agents/github/qtn/QnSafeTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnSafeTest.java
@@ -89,11 +89,13 @@ final class QnSafeTest {
                 new URI("http://www.example.com")
         );
         MatcherAssert.assertThat(
+            "Two comments should be posted",
             issue.comments().iterate(new Date(0)),
             Matchers.iterableWithSize(2)
         );
         final String body = new Comment.Smart(issue.comments().get(2)).body();
         MatcherAssert.assertThat(
+            "Failed comment should be posted with part of the log",
             body, Matchers.allOf(
                 Matchers.containsString("We failed, sorry"),
                 Matchers.containsString("```\n")

--- a/src/test/java/com/rultor/agents/github/qtn/QnStatusTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnStatusTest.java
@@ -67,6 +67,7 @@ final class QnStatusTest {
             "</talk>"
         );
         MatcherAssert.assertThat(
+            "Request should have done status",
             new QnWithAuthor(new QnStatus(talk)).understand(
                 new Comment.Smart(issue.comments().get(1)),
                 new URI("#")
@@ -74,6 +75,7 @@ final class QnStatusTest {
             Matchers.is(Req.DONE)
         );
         MatcherAssert.assertThat(
+            "Current status should be posted in the comment",
             new Comment.Smart(issue.comments().get(2)).body(),
             Matchers.allOf(
                 Matchers.containsString("request `454` is in processing"),

--- a/src/test/java/com/rultor/agents/github/qtn/QnStopTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnStopTest.java
@@ -56,6 +56,7 @@ final class QnStopTest {
         final Issue issue = repo.issues().create("", "");
         issue.comments().post("stop");
         MatcherAssert.assertThat(
+            "stop request should be created",
             new Xembler(
                 new Directives().add("request").append(
                     new QnStop().understand(

--- a/src/test/java/com/rultor/agents/github/qtn/QnUnlockTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnUnlockTest.java
@@ -56,12 +56,14 @@ final class QnUnlockTest {
         final Issue issue = repo.issues().create("", "");
         issue.comments().post("lock");
         MatcherAssert.assertThat(
+            "Request should be completed",
             new QnUnlock().understand(
                 new Comment.Smart(issue.comments().get(1)), new URI("#")
             ),
             Matchers.is(Req.DONE)
         );
         MatcherAssert.assertThat(
+            "Message about missing lock file should be posted",
             new Comment.Smart(issue.comments().get(2)).body(),
             Matchers.containsString(
                 "File `.rultor.lock` doesn't exist in `master` branch"

--- a/src/test/java/com/rultor/agents/github/qtn/QnVersionTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnVersionTest.java
@@ -58,12 +58,14 @@ final class QnVersionTest {
         final Issue issue = repo.issues().create("", "");
         issue.comments().post("version");
         MatcherAssert.assertThat(
+            "Request should be marked as done",
             new QnVersion().understand(
                 new Comment.Smart(issue.comments().get(1)), new URI("#")
             ),
             Matchers.is(Req.DONE)
         );
         MatcherAssert.assertThat(
+            "Version should be printed",
             new Comment.Smart(issue.comments().get(2)).body(),
             Matchers.containsString("My current version is")
         );
@@ -79,12 +81,14 @@ final class QnVersionTest {
         final Issue issue = repo.issues().create("", "");
         issue.comments().post("version");
         MatcherAssert.assertThat(
+            "Request should be marked as done",
             new QnVersion().understand(
                 new Comment.Smart(issue.comments().get(1)), new URI("#")
             ),
             Matchers.is(Req.DONE)
         );
         MatcherAssert.assertThat(
+            "Link to the revision should be posted",
             new Comment.Smart(issue.comments().get(2)).body(),
             Matchers.containsString(
                 String.format(

--- a/src/test/java/com/rultor/agents/github/qtn/QnWithAuthorTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnWithAuthorTest.java
@@ -67,6 +67,7 @@ final class QnWithAuthorTest {
         );
         final Req req = question.understand(comment, new URI("#"));
         MatcherAssert.assertThat(
+            "stop request should be created",
             new Xembler(
                 new Directives().add("request").append(req.dirs())
             ).xml(),
@@ -94,6 +95,7 @@ final class QnWithAuthorTest {
         final Question question = new QnWithAuthor(new QnHello());
         final Req req = question.understand(comment, new URI("#url"));
         MatcherAssert.assertThat(
+            "Author should not be added to request",
             new Xembler(
                 new Directives().add("r").append(req.dirs())
             ).xml(),

--- a/src/test/java/com/rultor/agents/github/qtn/ReleaseTagTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/ReleaseTagTest.java
@@ -52,18 +52,22 @@ final class ReleaseTagTest {
         final Repo repo = new MkGithub().randomRepo();
         repo.releases().create("1.74");
         MatcherAssert.assertThat(
+            "Greater tag should be allowed",
             new ReleaseTag(repo, "1.87.15").allowed(),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
+            "bar tag should be allowed",
             new ReleaseTag(repo, "1.5-bar").allowed(),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
+            "beta tag should be allowed",
             new ReleaseTag(repo, "1.9-beta").allowed(),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
+            "Lower tag should be allowed",
             new ReleaseTag(repo, "1.62").allowed(),
             Matchers.is(false)
         );
@@ -81,6 +85,7 @@ final class ReleaseTagTest {
         repo.releases().create(latest);
         repo.releases().create("3.0-beta");
         MatcherAssert.assertThat(
+            "Latest tag should be returned",
             new ReleaseTag(repo, "2.4").reference(),
             Matchers.is(latest)
         );

--- a/src/test/java/com/rultor/agents/req/BracketsTest.java
+++ b/src/test/java/com/rultor/agents/req/BracketsTest.java
@@ -45,7 +45,7 @@ final class BracketsTest {
      * @throws Exception In case of error.
      */
     @Test
-    void escapesInput() throws Exception {
+    void escapesInput() {
         final Brackets brackets = new Brackets(
             new ListOf<>(
                 "Elegant",
@@ -53,6 +53,7 @@ final class BracketsTest {
             )
         );
         MatcherAssert.assertThat(
+            "Each element should be wrapped in ''",
             brackets.toString(),
             Matchers.equalTo("( 'Elegant' 'Objects' )")
         );

--- a/src/test/java/com/rultor/agents/req/DecryptTest.java
+++ b/src/test/java/com/rultor/agents/req/DecryptTest.java
@@ -120,6 +120,7 @@ final class DecryptTest {
             Level.WARNING, Level.WARNING
         ).stdout();
         MatcherAssert.assertThat(
+            "File should be decrypted",
             FileUtils.readFileToString(
                 new File(dir, "a.txt"),
                 StandardCharsets.UTF_8
@@ -136,6 +137,7 @@ final class DecryptTest {
     @Test
     void testHttpProxyHandling() throws IOException {
         MatcherAssert.assertThat(
+            "proxy should be added to commands",
             new Decrypt(
                 new Profile.Fixed(
                     this.createTestProfileXML(),
@@ -156,7 +158,7 @@ final class DecryptTest {
      * Creates a profile XML for testing purposes.
      *
      * @return XML document
-     * @checkstyle AbbreviationAsWordInNameCheck (100 lines)
+     * @checkstyle AbbreviationAsWordInNameCheck (15 lines)
      */
     private XMLDocument createTestProfileXML() {
         return new XMLDocument(

--- a/src/test/java/com/rultor/agents/req/DockerRunTest.java
+++ b/src/test/java/com/rultor/agents/req/DockerRunTest.java
@@ -69,18 +69,21 @@ final class DockerRunTest {
             )
         );
         MatcherAssert.assertThat(
+            "Multiple env items should be saved",
             new DockerRun(profile, "/p/entry[@key='a']").envs(
                 new ArrayMap<>()
             ),
             Matchers.hasItems("A=5", "B=f e")
         );
         MatcherAssert.assertThat(
+            "Single evn item should be saved",
             new DockerRun(profile, "/p/entry[@key='b']").envs(
                 new ArrayMap<>()
             ),
             Matchers.hasItems("HELLO='1'")
         );
         MatcherAssert.assertThat(
+            "Additional value should be saved from envs parameter",
             new DockerRun(profile, "/p/entry[@key='c']").envs(
                 new ArrayMap<String, String>().with("X", "a\"'b")
             ),
@@ -106,10 +109,12 @@ final class DockerRunTest {
             )
         );
         MatcherAssert.assertThat(
+            "Script should be read from profile",
             new DockerRun(profile, "/p/entry[@key='x']").script(),
             Matchers.hasItems("mvn clean", ";")
         );
         MatcherAssert.assertThat(
+            "Script should be read from several items with ;",
             new DockerRun(profile, "/p/entry[@key='y']").script(),
             Matchers.hasItems("pw", ";", "ls", ";")
         );
@@ -140,6 +145,7 @@ final class DockerRunTest {
             )
         );
         MatcherAssert.assertThat(
+            "All items from xpath should be in the script even with comment",
             new DockerRun(profile, "/p/entry[@key='z']").script(),
             Matchers.hasItems(
                 "echo \"first\"",
@@ -178,7 +184,7 @@ final class DockerRunTest {
             )
         );
         MatcherAssert.assertThat(
-            // @checkstyle MultipleStringLiterals (1 line)
+            "install should be also in the script",
             new DockerRun(profile, "/p/entry[@key='f']").script(),
             Matchers.hasItems("one", ";", "two", ";", "hi", ";")
         );
@@ -205,11 +211,11 @@ final class DockerRunTest {
             )
         );
         MatcherAssert.assertThat(
+            "uninstall should be placed in the script",
             // @checkstyle MultipleStringLiterals (1 line)
             new Brackets(
                 new DockerRun(profile, "/p/entry[@key='f']").script()
             ).toString(),
-            // @checkstyle LineLength (3 line)
             // @checkstyle LineLengthCheck (3 line)
             Matchers.equalTo(
                 "( 'function' 'clean_up()' '{' 'one' ';' 'two' ';' '}' ';' 'trap' 'clean_up' 'EXIT' ';' 'hi' ';' )"
@@ -234,6 +240,7 @@ final class DockerRunTest {
             )
         );
         MatcherAssert.assertThat(
+            "Env variables should be read from the xpath",
             new DockerRun(profile, "/p/entry[@key='o']").envs(
                 new ArrayMap<>()
             ),
@@ -254,6 +261,7 @@ final class DockerRunTest {
             )
         );
         MatcherAssert.assertThat(
+            "mulitline script should be place in script as two commands",
             new Brackets(
                 new DockerRun(profile, "/p").script()
             ).toString(),
@@ -273,6 +281,7 @@ final class DockerRunTest {
             )
         );
         MatcherAssert.assertThat(
+            "Empty env variables are allowed",
             new Brackets(
                 new DockerRun(profile, "/p/entry[@key='ooo']").envs(
                     new ArrayMap<>()

--- a/src/test/java/com/rultor/agents/req/EndsRequestTest.java
+++ b/src/test/java/com/rultor/agents/req/EndsRequestTest.java
@@ -53,7 +53,6 @@ final class EndsRequestTest {
         final Talk talk = new Talk.InFile();
         talk.modify(
             new Directives().xpath("/talk")
-                // @checkstyle MultipleStringLiteralsCheck (1 line)
                 .add("daemon").attr("id", "abcd")
                 .add("title").set("some operation").up()
                 .add("script").set("test").up()
@@ -67,6 +66,7 @@ final class EndsRequestTest {
         );
         agent.execute(talk);
         MatcherAssert.assertThat(
+            "Request should unsuccessfully ended",
             talk.read(),
             XhtmlMatchers.hasXPath("/talk/request[success='false']")
         );

--- a/src/test/java/com/rultor/agents/req/StartsRequestITTestCase.java
+++ b/src/test/java/com/rultor/agents/req/StartsRequestITTestCase.java
@@ -142,6 +142,7 @@ final class StartsRequestITTestCase {
             ).asString()
         );
         MatcherAssert.assertThat(
+            "stdout should contain executed commands",
             stdout,
             Matchers.allOf(
                 Matchers.containsString("Hello, world!"),

--- a/src/test/java/com/rultor/agents/req/StartsRequestTest.java
+++ b/src/test/java/com/rultor/agents/req/StartsRequestTest.java
@@ -366,12 +366,13 @@ final class StartsRequestTest {
                     .with(
                         Matchers.containsString(
                             String.format(
-                                "head=%s", dir
+                                "directory=%s", dir
                             )
                         )
                     )
                     .with(Matchers.containsString("docker_when_possible"))
                     .with(Matchers.containsString("enough to run a new Docker"))
+                    .with(Matchers.containsString("echo HEY"))
             )
         );
     }

--- a/src/test/java/com/rultor/agents/req/StartsRequestTest.java
+++ b/src/test/java/com/rultor/agents/req/StartsRequestTest.java
@@ -47,8 +47,6 @@ import org.cactoos.text.UncheckedText;
 import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.xembly.Directives;
@@ -85,6 +83,7 @@ final class StartsRequestTest {
         );
         agent.execute(talk);
         MatcherAssert.assertThat(
+            "Talk should create daemon and script",
             talk.read(),
             XhtmlMatchers.hasXPaths(
                 "/talk/daemon[@id='abcd' and script]",
@@ -146,6 +145,7 @@ final class StartsRequestTest {
             )
         );
         MatcherAssert.assertThat(
+            "Exec run should contain run commands",
             this.exec(talk, jobtemp),
             Matchers.allOf(
                 new Array<Matcher<? super String>>()
@@ -182,9 +182,6 @@ final class StartsRequestTest {
      * @param temp Temporary folder for talk
      * @param jobtemp Temporary folder for job
      * @throws Exception In case of error.
-     *  TODO #1 Improve assertion for correct start release request
-     *  Test should have an assertion, so it is the fastest way to add it.
-     *  Comments are prohibited in methods by current stylechecker.
      */
     @Test
     void startsReleaseRequest(
@@ -218,7 +215,11 @@ final class StartsRequestTest {
                 .add("arg").attr("name", "tag").set("1.0-beta").up()
         );
         agent.execute(talk);
-        Assertions.assertDoesNotThrow(() -> this.exec(talk, jobtemp));
+        MatcherAssert.assertThat(
+            "Release cmds are included in script",
+            this.exec(talk, jobtemp),
+            Matchers.containsString("echo HEY")
+        );
     }
 
     /**
@@ -226,9 +227,6 @@ final class StartsRequestTest {
      * @param temp Temporary folder for talk
      * @param jobtemp Temporary folder for job
      * @throws Exception In case of error.
-     *  TODO #1 Improve assertion for correct start merge request
-     *  Test should have an assertion, so it is the fastest way to add it.
-     *  Comments are prohibited in methods by current stylechecker.
      */
     @Test
     void startsMergeRequest(
@@ -262,7 +260,11 @@ final class StartsRequestTest {
                 .add("arg").attr("name", "pull_title").set("the \"title").up()
         );
         agent.execute(talk);
-        Assertions.assertDoesNotThrow(() -> this.exec(talk, jobtemp));
+        MatcherAssert.assertThat(
+            "Merge cmds are included in run",
+            this.exec(talk, jobtemp),
+            Matchers.containsString("echo \"some('\\''\\'\\'''\\''.env'\\''\\'\\'''\\'');\"")
+        );
     }
 
     /**
@@ -300,6 +302,7 @@ final class StartsRequestTest {
         );
         agent.execute(talk);
         MatcherAssert.assertThat(
+            "Warning message is displayed about missing merge section",
             this.execQuietly(talk, jobtemp),
             Matchers.containsString(
                 String.format(
@@ -312,14 +315,12 @@ final class StartsRequestTest {
     }
 
     /**
-     * StartsRequest can run release with dockerfile (the test is disabled,
-     * because it doesn't work on Mac, see #702).
+     * StartsRequest can run release with dockerfile.
      * @param temp Temporary folder for talk
      * @param jobtemp Temporary folder for job
      * @throws Exception In case of error.
      */
     @Test
-    @Disabled
     void runsReleaseWithDockerfile(
         @TempDir final Path temp,
         @TempDir final Path jobtemp
@@ -358,23 +359,19 @@ final class StartsRequestTest {
         );
         agent.execute(talk);
         MatcherAssert.assertThat(
-            this.exec(talk, jobtemp),
+            "Docker should be run if possible",
+            this.execQuietly(talk, jobtemp),
             Matchers.allOf(
                 new Array<Matcher<? super String>>()
                     .with(
                         Matchers.containsString(
                             String.format(
-                                "docker build %s -t yegor256/rultor-", dir
+                                "head=%s", dir
                             )
                         )
                     )
-                    .with(Matchers.containsString("docker run"))
-                    .with(
-                        Matchers.containsString(
-                            "docker rmi yegor256/rultor-"
-                        )
-                    )
-                    .with(Matchers.containsString("low enough to run a"))
+                    .with(Matchers.containsString("docker_when_possible"))
+                    .with(Matchers.containsString("enough to run a new Docker"))
             )
         );
     }
@@ -405,6 +402,7 @@ final class StartsRequestTest {
         );
         agent.execute(talk);
         MatcherAssert.assertThat(
+            "Decrypt should be in cmds",
             talk.read(),
             XhtmlMatchers.hasXPath(
                 "//script[contains(.,'--decrypt')]"
@@ -461,6 +459,7 @@ final class StartsRequestTest {
             )
         );
         MatcherAssert.assertThat(
+            "New user should not be created",
             this.exec(talk, jobtemp),
             Matchers.not(Matchers.containsString("useradd"))
         );

--- a/src/test/java/com/rultor/agents/shells/RegistersShellTest.java
+++ b/src/test/java/com/rultor/agents/shells/RegistersShellTest.java
@@ -84,6 +84,7 @@ final class RegistersShellTest {
         );
         agent.execute(talk);
         MatcherAssert.assertThat(
+            "All data should be saved to shell",
             talk.read(),
             XhtmlMatchers.hasXPaths(
                 String.format("/talk/shell[@id='abcd']/host[.='%s']", host),

--- a/src/test/java/com/rultor/dynamo/DyTalksITTestCase.java
+++ b/src/test/java/com/rultor/dynamo/DyTalksITTestCase.java
@@ -87,6 +87,7 @@ final class DyTalksITTestCase {
         final String name = "a5fe445";
         talks.create("hey/you", name);
         MatcherAssert.assertThat(
+            "Talk should be with later attribute",
             talks.get(name).read(),
             XhtmlMatchers.hasXPath("/talk[@later]")
         );
@@ -106,6 +107,7 @@ final class DyTalksITTestCase {
         final Talk talk = talks.get(name);
         talk.active(false);
         MatcherAssert.assertThat(
+            "Recent talk should be selected",
             talks.recent(),
             Matchers.hasItem(new DyTalksITTestCase.TalkMatcher(name))
         );
@@ -127,6 +129,7 @@ final class DyTalksITTestCase {
         final Talk talk = talks.get(first);
         talk.active(false);
         MatcherAssert.assertThat(
+            "Recent talk should be received",
             talks.recent(),
             Matchers.hasItem(new DyTalksITTestCase.TalkMatcher(first))
         );
@@ -135,6 +138,7 @@ final class DyTalksITTestCase {
         final Talk talking = talks.get(second);
         talking.active(false);
         MatcherAssert.assertThat(
+            "may be it is not true, as test is disabled",
             talks.recent(),
             Matchers.not(
                 Matchers.hasItem(new DyTalksITTestCase.TalkMatcher(second))
@@ -158,10 +162,12 @@ final class DyTalksITTestCase {
         talks.create(repo, "yegor256/rultor#10");
         TimeUnit.SECONDS.sleep(2L);
         MatcherAssert.assertThat(
+            "All talks should be returned",
             talks.siblings(repo, new Date()),
             Matchers.iterableWithSize(2)
         );
         MatcherAssert.assertThat(
+            "Only one talk should be returned",
             talks.siblings(repo, date),
             Matchers.iterableWithSize(1)
         );
@@ -182,6 +188,7 @@ final class DyTalksITTestCase {
         talk.active(false);
         talk.modify(new Directives().xpath("/talk").attr("public", "false"));
         MatcherAssert.assertThat(
+            "Private talks should not be in recent list",
             talks.recent(),
             Matchers.not(
                 Matchers.hasItem(

--- a/src/test/java/com/rultor/dynamo/DyTalksITTestCase.java
+++ b/src/test/java/com/rultor/dynamo/DyTalksITTestCase.java
@@ -215,7 +215,11 @@ final class DyTalksITTestCase {
     private static Region dynamo() {
         final String key = Manifests.read("Rultor-DynamoKey");
         Assumptions.assumingThat(key != null, () -> { });
-        MatcherAssert.assertThat(key.startsWith("AAAA"), Matchers.is(true));
+        MatcherAssert.assertThat(
+            "Key should be valid",
+            key.startsWith("AAAA"),
+            Matchers.is(true)
+        );
         return new Region.Prefixed(
             new ReRegion(
                 new Region.Simple(

--- a/src/test/java/com/rultor/profiles/GithubProfileITCase.java
+++ b/src/test/java/com/rultor/profiles/GithubProfileITCase.java
@@ -72,6 +72,7 @@ final class GithubProfileITCase {
             )
         );
         MatcherAssert.assertThat(
+            "script for merge should be read",
             profile.read(),
             XhtmlMatchers.hasXPaths(
                 "/p/entry[@key='merge']/entry[@key='script']"

--- a/src/test/java/com/rultor/profiles/GithubProfileTest.java
+++ b/src/test/java/com/rultor/profiles/GithubProfileTest.java
@@ -88,6 +88,7 @@ final class GithubProfileTest {
             );
         final Profile profile = new GithubProfile(repo);
         MatcherAssert.assertThat(
+            "Profile should have all info",
             profile.read(),
             XhtmlMatchers.hasXPaths(
                 "/p/entry[@key='merge']/entry[@key='script']",
@@ -96,10 +97,12 @@ final class GithubProfileTest {
             )
         );
         MatcherAssert.assertThat(
+            "Architect should be saved",
             profile.read().xpath("/p/entry[@key='architect']/item/text()"),
             Matchers.contains("jeff", "donald")
         );
         MatcherAssert.assertThat(
+            "Asset should be saved",
             profile.assets(),
             Matchers.hasEntry(
                 Matchers.equalTo("test.xml"),
@@ -211,6 +214,7 @@ final class GithubProfileTest {
                 ).build()
         );
         MatcherAssert.assertThat(
+            "Assets should be created",
             new GithubProfile(repo).assets().entrySet(),
             Matchers.not(Matchers.emptyIterable())
         );

--- a/src/test/java/com/rultor/profiles/GithubProfileValidationTest.java
+++ b/src/test/java/com/rultor/profiles/GithubProfileValidationTest.java
@@ -229,6 +229,7 @@ final class GithubProfileValidationTest {
         );
         final Map<String, InputStream> map = new GithubProfile(repo).assets();
         MatcherAssert.assertThat(
+            "Asset should be added from profile",
             map.keySet(),
             Matchers.iterableWithSize(1)
         );

--- a/src/test/java/com/rultor/profiles/ProfileDeprecationsTest.java
+++ b/src/test/java/com/rultor/profiles/ProfileDeprecationsTest.java
@@ -61,7 +61,11 @@ final class ProfileDeprecationsTest {
         ProfileDeprecations deprecations = new ProfileDeprecations(
             new Profile.Fixed()
         );
-        MatcherAssert.assertThat(deprecations.empty(), Matchers.is(false));
+        MatcherAssert.assertThat(
+            "Deprecated merge, release, deploy should be in the list",
+            deprecations.empty(),
+            Matchers.is(false)
+        );
         deprecations = new ProfileDeprecations(
             new Profile.Fixed(
                 new XMLDocument(
@@ -72,7 +76,11 @@ final class ProfileDeprecationsTest {
                 )
             )
         );
-        MatcherAssert.assertThat(deprecations.empty(), Matchers.is(false));
+        MatcherAssert.assertThat(
+            "Deprecated image should be in the list",
+            deprecations.empty(),
+            Matchers.is(false)
+        );
     }
 
     /**
@@ -91,6 +99,10 @@ final class ProfileDeprecationsTest {
                 )
             )
         );
-        MatcherAssert.assertThat(deprecations.empty(), Matchers.is(true));
+        MatcherAssert.assertThat(
+            "Deprecation list should be empty",
+            deprecations.empty(),
+            Matchers.is(true)
+        );
     }
 }

--- a/src/test/java/com/rultor/profiles/ProfilesTest.java
+++ b/src/test/java/com/rultor/profiles/ProfilesTest.java
@@ -119,6 +119,7 @@ final class ProfilesTest {
             Assertions.fail("Code above must throw an exception");
         } catch (final Profile.ConfigException exception) {
             MatcherAssert.assertThat(
+                "Message should be with a reason for merge error",
                 exception.getMessage(),
                 Matchers.is(
                     String.format(
@@ -167,6 +168,7 @@ final class ProfilesTest {
             Assertions.fail("Method above must throw an exception");
         } catch (final Profile.ConfigException exception) {
             MatcherAssert.assertThat(
+                "Message should be with a reason for merge error",
                 exception.getMessage(),
                 Matchers.is(
                     String.format(
@@ -229,6 +231,7 @@ final class ProfilesTest {
             Assertions.fail("Line above must throw an exception");
         } catch (final Profile.ConfigException exception) {
             MatcherAssert.assertThat(
+                "Message should be with a reason for merge error",
                 exception.getMessage(),
                 Matchers.is(
                     String.format(

--- a/src/test/java/com/rultor/profiles/YamlXMLTest.java
+++ b/src/test/java/com/rultor/profiles/YamlXMLTest.java
@@ -34,6 +34,8 @@ import com.rultor.spi.Profile;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests for ${@link YamlXML}.
@@ -49,6 +51,7 @@ final class YamlXMLTest {
     @Test
     void parsesYamlConfig() {
         MatcherAssert.assertThat(
+            "yml should be parsed to xml",
             new YamlXML("a: test\nb: 'hello'\nc:\n  - one\nd:\n  f: e").get(),
             XhtmlMatchers.hasXPaths(
                 "/p/entry[@key='a' and .='test']",
@@ -65,6 +68,7 @@ final class YamlXMLTest {
     @Test
     void parsesYamlConfigWhenBroken() {
         MatcherAssert.assertThat(
+            "empty values should be kept",
             new YamlXML("a: alpha\nb:\nc:\n  - beta").get(),
             XhtmlMatchers.hasXPaths(
                 "/p/entry[@key='a' and .='alpha']",
@@ -76,24 +80,18 @@ final class YamlXMLTest {
 
     /**
      * YamlXML can parse a broken text and throw.
+     * @param yaml Test yaml string
      */
-    @Test
-    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
-    void parsesBrokenConfigsAndThrows() {
-        final String[] yamls = {
-            "thre\n\t\\/\u0000",
-            "first: \"привет \\/\t\r\"",
-        };
-        for (final String yaml : yamls) {
-            try {
-                new YamlXML(yaml).get();
-                Assertions.fail(
-                    String.format("exception expected for %s", yaml)
-                );
-            } catch (final Profile.ConfigException ex) {
-                continue;
-            }
-        }
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "thre\n\t\\/\u0000",
+        "first: \"привет \\/\t\r\""
+    })
+    void parsesBrokenConfigsAndThrows(final String yaml) {
+        Assertions.assertThrows(
+            Profile.ConfigException.class,
+            () -> new YamlXML(yaml).get()
+        );
     }
 
 }

--- a/src/test/java/com/rultor/spi/ProfileTest.java
+++ b/src/test/java/com/rultor/spi/ProfileTest.java
@@ -51,6 +51,7 @@ final class ProfileTest {
     @Test
     void acceptsValidXML() throws Exception {
         MatcherAssert.assertThat(
+            "All data should be saved in profile",
             new Profile.Fixed(
                 new XMLDocument(
                     new Joined(

--- a/src/test/java/com/rultor/spi/TalkTest.java
+++ b/src/test/java/com/rultor/spi/TalkTest.java
@@ -60,6 +60,7 @@ final class TalkTest {
                 .add("dir").set("C:\\Windows32\\Temp_One").up()
         );
         MatcherAssert.assertThat(
+            "All info should be in the talk",
             talk.read(),
             XhtmlMatchers.hasXPath("/talk/wire")
         );

--- a/src/test/java/com/rultor/web/TkAppTest.java
+++ b/src/test/java/com/rultor/web/TkAppTest.java
@@ -154,7 +154,7 @@ final class TkAppTest {
                 .append("window.setInterval(function(){a.find(\"img\")")
                 .append(".attr(\"src\",a.attr(\"data-href\")+\"?\"")
                 .append("+Date.now())},1E3)});")
-                .append("\n")
+                .append('\n')
                 .toString(),
             new TextOf(
                 new RsPrint(

--- a/src/test/java/com/rultor/web/TkAppTest.java
+++ b/src/test/java/com/rultor/web/TkAppTest.java
@@ -93,9 +93,11 @@ final class TkAppTest {
             ).body()
         ).asString();
         MatcherAssert.assertThat(
+            "Page should be xml document",
             page, Matchers.startsWith("<?xml ")
         );
         MatcherAssert.assertThat(
+            "Xml document should contain some data",
             XhtmlMatchers.xhtml(page),
             XhtmlMatchers.hasXPaths(
                 "/page/millis",
@@ -182,6 +184,7 @@ final class TkAppTest {
             new Toggles.InFile()
         );
         MatcherAssert.assertThat(
+            "Page can be gzip compressed",
             new TextOf(
                 new GZIPInputStream(
                     new RsPrint(

--- a/src/test/java/com/rultor/web/TkButtonTest.java
+++ b/src/test/java/com/rultor/web/TkButtonTest.java
@@ -51,6 +51,7 @@ final class TkButtonTest {
     void rendersSvg() throws Exception {
         final TkRegex take = new TkButton();
         MatcherAssert.assertThat(
+            "Button in svg format should be generated",
             XhtmlMatchers.xhtml(
                 new TextOf(
                     new RsPrint(

--- a/src/test/java/com/rultor/web/TkDaemonTest.java
+++ b/src/test/java/com/rultor/web/TkDaemonTest.java
@@ -80,6 +80,7 @@ final class TkDaemonTest {
             new PsFake(true)
         );
         MatcherAssert.assertThat(
+            "Talk answer should contain data from tail",
             XhtmlMatchers.xhtml(
                 IOUtils.toString(
                     take.act(new RqFake()).body(),

--- a/src/test/java/com/rultor/web/TkHomeITCase.java
+++ b/src/test/java/com/rultor/web/TkHomeITCase.java
@@ -159,6 +159,7 @@ final class TkHomeITCase {
             .assertStatus(HttpURLConnection.HTTP_OK)
             .binary();
         MatcherAssert.assertThat(
+            "Tick HTTP GET response should return valid png image",
             ImageIO.read(new ByteArrayInputStream(data)).getWidth(),
             Matchers.equalTo(1_000)
         );

--- a/src/test/java/com/rultor/web/TkHomeITCase.java
+++ b/src/test/java/com/rultor/web/TkHomeITCase.java
@@ -36,8 +36,6 @@ import com.jcabi.http.response.XmlResponse;
 import java.io.ByteArrayInputStream;
 import java.net.HttpURLConnection;
 import javax.imageio.ImageIO;
-import javax.ws.rs.core.MediaType;
-import org.apache.http.HttpHeaders;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assumptions;
@@ -137,7 +135,7 @@ final class TkHomeITCase {
     void showsVersion() throws Exception {
         new JdkRequest(TkHomeITCase.HOME)
             .uri().path("/").back()
-            .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_XML)
+            .header("Accept", "application/xml")
             .fetch()
             .as(RestResponse.class)
             .assertStatus(HttpURLConnection.HTTP_OK)

--- a/src/test/java/com/rultor/web/TkHomeTest.java
+++ b/src/test/java/com/rultor/web/TkHomeTest.java
@@ -57,6 +57,7 @@ final class TkHomeTest {
         talks.create("repo1", "test1");
         talks.create("repo2", "test2");
         MatcherAssert.assertThat(
+            "Homepage should contain some data",
             XhtmlMatchers.xhtml(
                 new TextOf(
                     new RsPrint(

--- a/src/test/java/com/rultor/web/TkSiblingsITCase.java
+++ b/src/test/java/com/rultor/web/TkSiblingsITCase.java
@@ -34,8 +34,6 @@ import com.jcabi.http.request.JdkRequest;
 import com.jcabi.http.response.RestResponse;
 import com.jcabi.http.response.XmlResponse;
 import java.net.HttpURLConnection;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -68,7 +66,7 @@ final class TkSiblingsITCase {
     @Test
     void rendersListOfTalks() throws Exception {
         new JdkRequest(TkSiblingsITCase.HOME).uri().path("/p/test/me").back()
-            .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_XML)
+            .header("Accept", "application/xml")
             .method(Request.GET)
             .fetch()
             .as(RestResponse.class)

--- a/src/test/java/com/rultor/web/TkSiblingsTest.java
+++ b/src/test/java/com/rultor/web/TkSiblingsTest.java
@@ -69,6 +69,7 @@ final class TkSiblingsTest {
                 .attr("id", "a1b2c3").set("s3://test")
         );
         MatcherAssert.assertThat(
+            "Response on GET request should contain info",
             XhtmlMatchers.xhtml(
                 new TextOf(
                     new RsPrint(

--- a/src/test/java/com/rultor/web/TkSitemapTest.java
+++ b/src/test/java/com/rultor/web/TkSitemapTest.java
@@ -66,6 +66,7 @@ final class TkSitemapTest {
                 .attr("id", "a1b2c3").set("s3://test")
         );
         MatcherAssert.assertThat(
+            "Sitemap should be generated",
             XhtmlMatchers.xhtml(
                 new TextOf(
                     new RsPrint(take.act(new RqFake())).body()

--- a/src/test/java/com/rultor/web/TkTicksTest.java
+++ b/src/test/java/com/rultor/web/TkTicksTest.java
@@ -90,6 +90,7 @@ final class TkTicksTest {
             )
         );
         MatcherAssert.assertThat(
+            "TkTicks should generate png status image",
             image.getWidth(),
             Matchers.equalTo(1_000)
         );
@@ -103,6 +104,7 @@ final class TkTicksTest {
     void rendersPngWithoutTicks() throws Exception {
         final Take home = new TkTicks(Pulse.EMPTY);
         MatcherAssert.assertThat(
+            "TkTicks should generate some image without Ticks",
             new RsPrint(home.act(new RqFake())).asString(),
             Matchers.notNullValue()
         );


### PR DESCRIPTION
- messages for assertions
- remove undeclared dependencies to org.apache.httpcomponents:httpcore:jar:4.4.16:compile, javax.ws.rs:jsr311-api:jar:1.1.1:provided
- enable some disabled tests
