### PR TITLE
fix(#2326): treat skipped CI checks as non-failing during merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ ajcore*
 Gemfile.lock
 node_modules/
 target/
+.aidy/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.iml
+.factorypath
 *.log
 .claude/
 .DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
     <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-github</artifactId>
-      <version>1.10.0</version>
+      <version>1.11.1</version>
       <exclusions>
         <exclusion>
           <groupId>jakarta.ws.rs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,19 @@
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
-      <version>4.0.6</version>
+      <version>4.0.8</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>4.0.8</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+      <version>4.0.8</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -288,7 +300,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.21.0</version>
+      <version>2.22.0</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>

--- a/src/main/java/com/rultor/agents/github/CommentsTag.java
+++ b/src/main/java/com/rultor/agents/github/CommentsTag.java
@@ -104,15 +104,7 @@ public final class CommentsTag extends AbstractAgent {
                 )
             );
             Logger.info(this, "duplicate tag %s commented", tag);
-        } else if (!release.allowed()) {
-            issue.comments().post(
-                String.format(
-                    CommentsTag.PHRASES.getString("CommentsTag.outdated"),
-                    tag, release.reference()
-                )
-            );
-            Logger.info(this, "outdated tag %s commented", tag);
-        } else {
+        } else if (release.allowed()) {
             final Repo repo = issue.repo();
             final Date prev = CommentsTag.previous(repo);
             final Release.Smart rel = new Release.Smart(
@@ -130,6 +122,14 @@ public final class CommentsTag extends AbstractAgent {
                 )
             );
             Logger.info(this, "tag %s created and commented", tag);
+        } else {
+            issue.comments().post(
+                String.format(
+                    CommentsTag.PHRASES.getString("CommentsTag.outdated"),
+                    tag, release.reference()
+                )
+            );
+            Logger.info(this, "outdated tag %s commented", tag);
         }
         return new Directives();
     }

--- a/src/main/java/com/rultor/agents/github/qtn/CheckablePull.java
+++ b/src/main/java/com/rultor/agents/github/qtn/CheckablePull.java
@@ -42,7 +42,7 @@ final class CheckablePull {
     public boolean allChecksSuccessful() throws IOException {
         boolean result = true;
         for (final Check check : this.pull.checks().all()) {
-            if (!check.successful()) {
+            if (!check.successful() && !check.skipped()) {
                 result = false;
                 break;
             }

--- a/src/test/java/com/rultor/EntryTest.java
+++ b/src/test/java/com/rultor/EntryTest.java
@@ -6,6 +6,7 @@ package com.rultor;
 
 import co.stateful.RtSttc;
 import com.jcabi.github.RtGitHub;
+import com.jcabi.github.UnexpectedHttpStatus;
 import com.jcabi.urn.URN;
 import com.yegor256.WeAreOnline;
 import org.junit.jupiter.api.Assertions;
@@ -51,7 +52,7 @@ final class EntryTest {
     @Test
     void githubConnects() {
         Assertions.assertThrows(
-            AssertionError.class,
+            UnexpectedHttpStatus.class,
             () -> new RtGitHub("intentionally-invalid-token")
                 .users().self().login()
         );

--- a/src/test/java/com/rultor/agents/github/qtn/QnMergeTest.java
+++ b/src/test/java/com/rultor/agents/github/qtn/QnMergeTest.java
@@ -171,6 +171,31 @@ final class QnMergeTest {
     }
 
     /**
+     * QnMerge can build a request when some CI checks are skipped.
+     *
+     * @throws IOException In case of I/O error
+     * @throws URISyntaxException In case of URI error
+     */
+    @Test
+    void continuesBecauseSomeChecksAreSkipped()
+        throws IOException, URISyntaxException {
+        final MkChecks checks = (MkChecks) this.pull.checks();
+        checks.create(Check.Status.COMPLETED, Check.Conclusion.SUCCESS);
+        checks.create(Check.Status.COMPLETED, Check.Conclusion.SKIPPED);
+        this.mergeRequest();
+        MatcherAssert.assertThat(
+            "Merge should proceed when some checks are skipped",
+            new Comment.Smart(this.comments.get(2)).body(),
+            Matchers.containsString(
+                String.format(
+                    QnMergeTest.PHRASES.getString("QnMerge.start"),
+                    "#"
+                )
+            )
+        );
+    }
+
+    /**
      * QnMerge can not build a request because .rultor file is changed.
      * @throws IOException In case of I/O error
      * @throws URISyntaxException In case of URI error


### PR DESCRIPTION
Treats skipped CI checks as non-failures, allowing `@rultor merge` to proceed when checks are conditionally disabled rather than broken.

Fixes #2326