### PR TITLE
#2322 close Ec2Client at every call site in agents.aws

### DIFF
--- a/src/main/java/com/rultor/agents/aws/AwsEc2.java
+++ b/src/main/java/com/rultor/agents/aws/AwsEc2.java
@@ -56,7 +56,9 @@ public final class AwsEc2 {
     }
 
     /**
-     * AWS EC2 client instance.
+     * AWS EC2 client instance. The returned client owns an HTTP client,
+     * a thread pool, and a connection pool; the caller must close it
+     * (typically via try-with-resources) to release those resources.
      * @return AWS EC2 client
      */
     public Ec2Client aws() {

--- a/src/main/java/com/rultor/agents/aws/ConnectsInstance.java
+++ b/src/main/java/com/rultor/agents/aws/ConnectsInstance.java
@@ -15,6 +15,7 @@ import java.util.Date;
 import lombok.ToString;
 import org.xembly.Directive;
 import org.xembly.Directives;
+import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.DescribeInstanceStatusRequest;
 import software.amazon.awssdk.services.ec2.model.DescribeInstancesRequest;
 
@@ -74,25 +75,27 @@ public final class ConnectsInstance extends AbstractAgent {
                 instance, name, host
             );
         } else {
-            final long age = new Date().getTime() - this.api.aws()
-                .describeInstances(
-                    DescribeInstancesRequest.builder()
+            try (Ec2Client client = this.api.aws()) {
+                final long age = new Date().getTime() - client
+                    .describeInstances(
+                        DescribeInstancesRequest.builder()
+                            .instanceIds(instance)
+                            .build()
+                    )
+                    .reservations().get(0)
+                    .instances().get(0)
+                    .launchTime().toEpochMilli();
+                final String status = client.describeInstanceStatus(
+                    DescribeInstanceStatusRequest.builder()
+                        .includeAllInstances(true)
                         .instanceIds(instance)
                         .build()
-                )
-                .reservations().get(0)
-                .instances().get(0)
-                .launchTime().toEpochMilli();
-            final String status = this.api.aws().describeInstanceStatus(
-                DescribeInstanceStatusRequest.builder()
-                    .includeAllInstances(true)
-                    .instanceIds(instance)
-                    .build()
-            ).instanceStatuses().get(0).instanceState().nameAsString();
-            Logger.warn(
-                this, "Can't connect %s to AWS instance %s at %s (%[ms]s old, \"%s\")",
-                name, instance, host, age, status
-            );
+                ).instanceStatuses().get(0).instanceState().nameAsString();
+                Logger.warn(
+                    this, "Can't connect %s to AWS instance %s at %s (%[ms]s old, \"%s\")",
+                    name, instance, host, age, status
+                );
+            }
         }
         return dirs;
     }

--- a/src/main/java/com/rultor/agents/aws/DescribesInstance.java
+++ b/src/main/java/com/rultor/agents/aws/DescribesInstance.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import lombok.ToString;
 import org.xembly.Directive;
 import org.xembly.Directives;
+import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.DescribeInstanceStatusRequest;
 import software.amazon.awssdk.services.ec2.model.DescribeInstancesRequest;
 import software.amazon.awssdk.services.ec2.model.Instance;
@@ -46,23 +47,25 @@ public final class DescribesInstance extends AbstractAgent {
     @Override
     public Iterable<Directive> process(final XML xml) throws IOException {
         final String instance = xml.xpath("/talk/ec2/instance/text()").get(0);
-        final String state = this.api.aws().describeInstanceStatus(
-            DescribeInstanceStatusRequest.builder()
-                .includeAllInstances(true)
-                .instanceIds(instance)
-                .build()
-        ).instanceStatuses().get(0).instanceState().nameAsString();
-        Logger.info(this, "AWS instance %s state: %s", instance, state);
         final Directives dirs = new Directives();
-        if ("running".equals(state)) {
-            final Instance ready = this.api.aws().describeInstances(
-                DescribeInstancesRequest.builder()
+        try (Ec2Client client = this.api.aws()) {
+            final String state = client.describeInstanceStatus(
+                DescribeInstanceStatusRequest.builder()
+                    .includeAllInstances(true)
                     .instanceIds(instance)
                     .build()
-            ).reservations().get(0).instances().get(0);
-            final String host = ready.publicIpAddress();
-            dirs.xpath("/talk/ec2").add("host").set(host);
-            Logger.info(this, "AWS instance %s is at %s", instance, host);
+            ).instanceStatuses().get(0).instanceState().nameAsString();
+            Logger.info(this, "AWS instance %s state: %s", instance, state);
+            if ("running".equals(state)) {
+                final Instance ready = client.describeInstances(
+                    DescribeInstancesRequest.builder()
+                        .instanceIds(instance)
+                        .build()
+                ).reservations().get(0).instances().get(0);
+                final String host = ready.publicIpAddress();
+                dirs.xpath("/talk/ec2").add("host").set(host);
+                Logger.info(this, "AWS instance %s is at %s", instance, host);
+            }
         }
         return dirs;
     }

--- a/src/main/java/com/rultor/agents/aws/DetachesInstance.java
+++ b/src/main/java/com/rultor/agents/aws/DetachesInstance.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import lombok.ToString;
 import org.xembly.Directive;
 import org.xembly.Directives;
+import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.DescribeInstanceStatusRequest;
 import software.amazon.awssdk.services.ec2.model.DescribeInstanceStatusResponse;
 import software.amazon.awssdk.services.ec2.model.InstanceState;
@@ -42,12 +43,15 @@ public final class DetachesInstance extends AbstractAgent {
     @Override
     public Iterable<Directive> process(final XML xml) throws IOException {
         final String instance = xml.xpath("/talk/ec2/instance/text()").get(0);
-        final DescribeInstanceStatusResponse res = this.api.aws().describeInstanceStatus(
-            DescribeInstanceStatusRequest.builder()
-                .includeAllInstances(true)
-                .instanceIds(instance)
-                .build()
-        );
+        final DescribeInstanceStatusResponse res;
+        try (Ec2Client client = this.api.aws()) {
+            res = client.describeInstanceStatus(
+                DescribeInstanceStatusRequest.builder()
+                    .includeAllInstances(true)
+                    .instanceIds(instance)
+                    .build()
+            );
+        }
         final InstanceState state = res.instanceStatuses().get(0).instanceState();
         final Directives dirs = new Directives();
         if ("terminated".equals(state.nameAsString())) {

--- a/src/main/java/com/rultor/agents/aws/DropsInstance.java
+++ b/src/main/java/com/rultor/agents/aws/DropsInstance.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import lombok.ToString;
 import org.xembly.Directive;
 import org.xembly.Directives;
+import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.DescribeInstancesRequest;
 import software.amazon.awssdk.services.ec2.model.DescribeInstancesResponse;
 
@@ -43,11 +44,14 @@ public final class DropsInstance extends AbstractAgent {
     @Override
     public Iterable<Directive> process(final XML xml) throws IOException {
         final String instance = xml.xpath("/talk/ec2/instance/text()").get(0);
-        final DescribeInstancesResponse res = this.api.aws().describeInstances(
-            DescribeInstancesRequest.builder()
-                .instanceIds(instance)
-                .build()
-        );
+        final DescribeInstancesResponse res;
+        try (Ec2Client client = this.api.aws()) {
+            res = client.describeInstances(
+                DescribeInstancesRequest.builder()
+                    .instanceIds(instance)
+                    .build()
+            );
+        }
         final Directives dirs = new Directives();
         if (res.reservations().isEmpty()) {
             dirs.xpath("/talk/ec2").strict(1).remove();

--- a/src/main/java/com/rultor/agents/aws/PrunesInstances.java
+++ b/src/main/java/com/rultor/agents/aws/PrunesInstances.java
@@ -13,6 +13,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.LinkedList;
 import lombok.ToString;
+import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.DescribeInstanceStatusRequest;
 import software.amazon.awssdk.services.ec2.model.DescribeInstancesRequest;
 import software.amazon.awssdk.services.ec2.model.DescribeInstancesResponse;
@@ -52,48 +53,50 @@ public final class PrunesInstances implements SuperAgent {
 
     @Override
     public void execute(final Talks talks) throws IOException {
-        final DescribeInstancesResponse res = this.api.aws().describeInstances(
-            DescribeInstancesRequest.builder()
-                .filters(
-                    Filter.builder()
-                        .name("tag:rultor")
-                        .values("yes")
-                        .build()
-                )
-                .build()
-        );
         final Collection<String> seen = new LinkedList<>();
-        for (final Reservation rsrv : res.reservations()) {
-            final Instance instance = rsrv.instances().get(0);
-            final String status = this.api.aws().describeInstanceStatus(
-                DescribeInstanceStatusRequest.builder()
-                    .includeAllInstances(true)
-                    .instanceIds(instance.instanceId())
-                    .build()
-            ).instanceStatuses().get(0).instanceState().nameAsString();
-            final long age = new Date().getTime() - instance.launchTime().toEpochMilli();
-            final String label = Logger.format(
-                "%s/%s/%s/%[ms]s",
-                instance.instanceId(),
-                instance.instanceTypeAsString(),
-                status, age
-            );
-            if ("terminated".equals(status)) {
-                continue;
-            }
-            seen.add(label);
-            if (age < this.max) {
-                continue;
-            }
-            this.api.aws().terminateInstances(
-                TerminateInstancesRequest.builder()
-                    .instanceIds(instance.instanceId())
+        try (Ec2Client client = this.api.aws()) {
+            final DescribeInstancesResponse res = client.describeInstances(
+                DescribeInstancesRequest.builder()
+                    .filters(
+                        Filter.builder()
+                            .name("tag:rultor")
+                            .values("yes")
+                            .build()
+                    )
                     .build()
             );
-            Logger.warn(
-                this, "AWS instance %s is too old, terminated",
-                label
-            );
+            for (final Reservation rsrv : res.reservations()) {
+                final Instance instance = rsrv.instances().get(0);
+                final String status = client.describeInstanceStatus(
+                    DescribeInstanceStatusRequest.builder()
+                        .includeAllInstances(true)
+                        .instanceIds(instance.instanceId())
+                        .build()
+                ).instanceStatuses().get(0).instanceState().nameAsString();
+                final long age = new Date().getTime() - instance.launchTime().toEpochMilli();
+                final String label = Logger.format(
+                    "%s/%s/%s/%[ms]s",
+                    instance.instanceId(),
+                    instance.instanceTypeAsString(),
+                    status, age
+                );
+                if ("terminated".equals(status)) {
+                    continue;
+                }
+                seen.add(label);
+                if (age < this.max) {
+                    continue;
+                }
+                client.terminateInstances(
+                    TerminateInstancesRequest.builder()
+                        .instanceIds(instance.instanceId())
+                        .build()
+                );
+                Logger.warn(
+                    this, "AWS instance %s is too old, terminated",
+                    label
+                );
+            }
         }
         Logger.info(
             this, "Checked %d AWS instances: %[list]s",

--- a/src/main/java/com/rultor/agents/aws/ShootsInstance.java
+++ b/src/main/java/com/rultor/agents/aws/ShootsInstance.java
@@ -13,6 +13,7 @@ import java.util.Date;
 import lombok.ToString;
 import org.xembly.Directive;
 import org.xembly.Directives;
+import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.DescribeInstancesRequest;
 import software.amazon.awssdk.services.ec2.model.TerminateInstancesRequest;
 
@@ -54,26 +55,28 @@ public final class ShootsInstance extends AbstractAgent {
     @Override
     public Iterable<Directive> process(final XML xml) throws IOException {
         final String instance = xml.xpath("/talk/ec2/instance/text()").get(0);
-        final long age = new Date().getTime() - this.api.aws()
-            .describeInstances(
-                DescribeInstancesRequest.builder()
-                    .instanceIds(instance)
-                    .build()
-            )
-            .reservations().get(0)
-            .instances().get(0)
-            .launchTime().toEpochMilli();
-        if (age > this.max) {
-            this.api.aws().terminateInstances(
-                TerminateInstancesRequest.builder()
-                    .instanceIds(instance)
-                    .build()
-            );
-            Logger.warn(
-                this,
-                "Terminated AWS instance %s because it's %[ms]s old (most probably dead)",
-                instance, age
-            );
+        try (Ec2Client client = this.api.aws()) {
+            final long age = new Date().getTime() - client
+                .describeInstances(
+                    DescribeInstancesRequest.builder()
+                        .instanceIds(instance)
+                        .build()
+                )
+                .reservations().get(0)
+                .instances().get(0)
+                .launchTime().toEpochMilli();
+            if (age > this.max) {
+                client.terminateInstances(
+                    TerminateInstancesRequest.builder()
+                        .instanceIds(instance)
+                        .build()
+                );
+                Logger.warn(
+                    this,
+                    "Terminated AWS instance %s because it's %[ms]s old (most probably dead)",
+                    instance, age
+                );
+            }
         }
         return new Directives();
     }

--- a/src/main/java/com/rultor/agents/aws/StartsInstance.java
+++ b/src/main/java/com/rultor/agents/aws/StartsInstance.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import lombok.ToString;
 import org.xembly.Directive;
 import org.xembly.Directives;
+import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.Instance;
 import software.amazon.awssdk.services.ec2.model.ResourceType;
 import software.amazon.awssdk.services.ec2.model.RunInstancesRequest;
@@ -158,8 +159,10 @@ public final class StartsInstance extends AbstractAgent {
             "Starting a new AWS instance for '%s' (image=%s, type=%s, group=%s, subnet=%s)...",
             talk, this.image, itype, this.sgroup, this.subnet
         );
-        final RunInstancesResponse response =
-            this.api.aws().runInstances(request);
+        final RunInstancesResponse response;
+        try (Ec2Client client = this.api.aws()) {
+            response = client.runInstances(request);
+        }
         final Instance instance = response.instances().get(0);
         Logger.info(
             this,

--- a/src/main/java/com/rultor/agents/aws/TerminatesInstance.java
+++ b/src/main/java/com/rultor/agents/aws/TerminatesInstance.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import lombok.ToString;
 import org.xembly.Directive;
 import org.xembly.Directives;
+import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.TerminateInstancesRequest;
 
 /**
@@ -44,11 +45,13 @@ public final class TerminatesInstance extends AbstractAgent {
     @Override
     public Iterable<Directive> process(final XML xml) throws IOException {
         final String instance = xml.xpath("/talk/ec2/instance/text()").get(0);
-        this.api.aws().terminateInstances(
-            TerminateInstancesRequest.builder()
-                .instanceIds(instance)
-                .build()
-        );
+        try (Ec2Client client = this.api.aws()) {
+            client.terminateInstances(
+                TerminateInstancesRequest.builder()
+                    .instanceIds(instance)
+                    .build()
+            );
+        }
         Logger.info(
             this, "Successfully terminated %s instance of %s",
             instance, xml.xpath("/talk/@name").get(0)


### PR DESCRIPTION
The `Ec2Client` returned by `AwsEc2.aws()` is built fresh on every invocation and was never closed at the eight call sites in `com.rultor.agents.aws`. As `Ec2Client` owns an HTTP client, a thread pool, and a connection pool, every started or terminated EC2 instance leaked one full SDK client. Closes #2322.

This change wraps every `this.api.aws()` call in `ShootsInstance`, `ConnectsInstance`, `TerminatesInstance`, `DetachesInstance`, `DropsInstance`, `StartsInstance`, `PrunesInstances`, and `DescribesInstance` in try-with-resources so the client is released on the same statement that uses it. `AwsEc2.aws()` itself is unchanged in behavior; only its Javadoc now documents the caller's responsibility to close. No EC2 API call semantics, sequencing, or error handling moves.

Locally ran `mvn compile` and `mvn test-compile` on Java 21 — both green; the full `mvn install -Pqulice` was not exercised in this environment, so the qulice/checkstyle/PMD passes will land on the CI matrix.
