### PR TITLE
fix: avoid leaking GPG passphrase to build logs (#2325)

### DIFF
--- a/src/main/java/com/rultor/agents/daemons/StartsDaemon.java
+++ b/src/main/java/com/rultor/agents/daemons/StartsDaemon.java
@@ -170,12 +170,9 @@ public final class StartsDaemon implements Agent {
      */
     private void uploadGpgKey(final Shell shell) throws IOException {
         final String secring = System.getenv("GPG_SECRING");
-        if (secring.split("\n").length < 10) {
+        if (secring == null || secring.split("\n").length < 10) {
             throw new IOException(
-                String.format(
-                    "GPG secret key is too short in the GPG_SECRING environment variable: %s",
-                    secring
-                )
+                "GPG secret key is absent or too short in the GPG_SECRING environment variable"
             );
         }
         new Shell.Safe(shell).exec(

--- a/src/main/java/com/rultor/agents/req/Decrypt.java
+++ b/src/main/java/com/rultor/agents/req/Decrypt.java
@@ -67,13 +67,15 @@ final class Decrypt {
                     )
                 )
             );
+            commands.add("set +x");
             commands.add(
                 String.format(
                     String.join(
                         Decrypt.SPACE,
+                        "printf '%%s' %s |",
                         "gpg --no-tty --batch --verbose --decrypt",
                         "--ignore-mdc-error",
-                        "--passphrase %s %s > %s"
+                        "--passphrase-fd 0 %s > %s"
                     ),
                     Ssh.escape(
                         String.format("rultor-key:%s", this.profile.name())
@@ -82,6 +84,7 @@ final class Decrypt {
                     Ssh.escape(key)
                 )
             );
+            commands.add("set -x");
             commands.add(String.format("rm -rf %s ", Ssh.escape(enc)));
         }
         return commands;


### PR DESCRIPTION
Fixes the GPG passphrase leak described in issue https://github.com/yegor256/rultor/issues/2325.

Decrypt.commands() previously embedded the symmetric decryption passphrase (rultor-key:<profile-name>) directly on the gpg command line via --passphrase. Because build scripts run with set -x, every command — including the passphrase — was echoed to stdout and published in the publicly readable build logs.

This change:

Passes the passphrase to gpg through stdin using printf '%s' ... | gpg --passphrase-fd 0 instead of --passphrase <value>.
Wraps the passphrase-bearing line in set +x / set -x, so the printf is not echoed even though the surrounding script runs with set -x.
The passphrase no longer appears anywhere in the build log.