### PR TITLE
#2337: return false for empty issue URLs

### DIFF
--- a/src/main/java/com/rultor/agents/github/IssueUrl.java
+++ b/src/main/java/com/rultor/agents/github/IssueUrl.java
@@ -59,11 +59,8 @@ final class IssueUrl {
      * @return True if valid
      */
     public boolean valid() {
-        if (this.url == null || this.url.isEmpty()) {
-            throw new IllegalArgumentException(
-                "URL should not be empty"
-            );
-        }
-        return IssueUrl.CORRECT.matcher(this.url).matches();
+        return this.url != null
+            && !this.url.isEmpty()
+            && IssueUrl.CORRECT.matcher(this.url).matches();
     }
 }

--- a/src/test/java/com/rultor/agents/github/IssueUrlTest.java
+++ b/src/test/java/com/rultor/agents/github/IssueUrlTest.java
@@ -63,6 +63,24 @@ final class IssueUrlTest {
     }
 
     @Test
+    void emptyUrlShouldBeNotValid() {
+        MatcherAssert.assertThat(
+            "Empty url is not a valid github issue url",
+            new IssueUrl("").valid(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void nullUrlShouldBeNotValid() {
+        MatcherAssert.assertThat(
+            "Null url is not a valid github issue url",
+            new IssueUrl(null).valid(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
     void pullRequestIdShouldBeReturned() {
         final IssueUrl issue = new IssueUrl(
             "https://api.github.com/repos/USER/REPO/pulls/5186"


### PR DESCRIPTION
Fixes #2337.

Summary:
- Return false from IssueUrl.valid() when the URL is null or empty.
- Add focused tests for null and empty URLs.

Validation:
- mvn --errors --batch-mode -Dtest=IssueUrlTest test
- mvn -q -DskipTests qulice:check -Pqulice
- git diff --check
- git diff --no-ext-diff | gitleaks stdin --no-banner --redact --exit-code 1
- GitHub CI is green on the PR

No secrets included.