### PR TITLE
#2324: close private key asset stream

### DIFF
--- a/src/main/java/com/rultor/agents/shells/PfShell.java
+++ b/src/main/java/com/rultor/agents/shells/PfShell.java
@@ -8,6 +8,7 @@ import com.jcabi.aspects.Immutable;
 import com.jcabi.ssh.Ssh;
 import com.rultor.spi.Profile;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import lombok.EqualsAndHashCode;
@@ -125,14 +126,14 @@ public final class PfShell {
         if (path.isEmpty()) {
             key = this.pvt;
         } else {
-            if (this.profile.assets().get(path) == null) {
-                throw new Profile.ConfigException(
-                    String.format("Private SSH key not found at %s", path)
-                );
-            }
-            try {
+            try (InputStream input = this.profile.assets().get(path)) {
+                if (input == null) {
+                    throw new Profile.ConfigException(
+                        String.format("Private SSH key not found at %s", path)
+                    );
+                }
                 key = IOUtils.toString(
-                    this.profile.assets().get(path),
+                    input,
                     StandardCharsets.UTF_8
                 );
             } catch (final IOException ex) {

--- a/src/test/java/com/rultor/agents/shells/PfShellTest.java
+++ b/src/test/java/com/rultor/agents/shells/PfShellTest.java
@@ -1,0 +1,95 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2009-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.rultor.agents.shells;
+
+import com.jcabi.immutable.ArrayMap;
+import com.jcabi.xml.XMLDocument;
+import com.rultor.spi.Profile;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * Tests for {@link PfShell}.
+ *
+ * @since 1.77
+ */
+final class PfShellTest {
+
+    /**
+     * PfShell closes private key asset stream.
+     * @throws Exception If something goes wrong.
+     */
+    @Test
+    void closesPrivateKeyAssetStream() throws Exception {
+        final String path = "id_rsa";
+        final String pvt = "private-key";
+        final PfShellTest.CloseAwareInputStream stream =
+            new PfShellTest.CloseAwareInputStream(pvt);
+        final Profile profile = Mockito.mock(Profile.class);
+        Mockito.doReturn(
+            new XMLDocument(
+                String.join(
+                    "",
+                    "<p><entry key='ssh'><entry key='key'>",
+                    path,
+                    "</entry></entry></p>"
+                )
+            )
+        ).when(profile).read();
+        Mockito.doReturn(
+            new ArrayMap<String, InputStream>().with(path, stream)
+        ).when(profile).assets();
+        MatcherAssert.assertThat(
+            "Private key should be loaded from the profile asset",
+            new PfShell(profile, "localhost", 22, "rultor", "fallback").key(),
+            Matchers.equalTo(pvt)
+        );
+        MatcherAssert.assertThat(
+            "Private key asset stream should be closed after reading",
+            stream.closed(),
+            Matchers.is(true)
+        );
+    }
+
+    /**
+     * Input stream with close state.
+     *
+     * @since 1.77
+     */
+    private static final class CloseAwareInputStream
+        extends ByteArrayInputStream {
+
+        /**
+         * Whether close was called.
+         */
+        private transient boolean done;
+
+        /**
+         * Ctor.
+         * @param body Stream body
+         */
+        CloseAwareInputStream(final String body) {
+            super(body.getBytes(StandardCharsets.UTF_8));
+        }
+
+        @Override
+        public void close() {
+            this.done = true;
+        }
+
+        /**
+         * Check whether close was called.
+         * @return True if closed.
+         */
+        boolean closed() {
+            return this.done;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2324.

Summary:
- Read the configured private key asset stream once in `PfShell.key()`.
- Close the stream with try-with-resources after reading it.
- Add a focused regression proving the asset stream is closed.

Validation:
- `mvn -q -Dtest=PfShellTest test`
- `mvn -q -DskipTests qulice:check -Pqulice`
- `git diff --check`
- `typos src/main/java/com/rultor/agents/shells/PfShell.java src/test/java/com/rultor/agents/shells/PfShellTest.java`
- `git diff --cached --no-ext-diff | gitleaks stdin --no-banner --redact --exit-code 1`

No secrets included.