### PR TITLE
#2323: handle missing GPG_SECRING

### DIFF
--- a/src/main/java/com/rultor/agents/daemons/StartsDaemon.java
+++ b/src/main/java/com/rultor/agents/daemons/StartsDaemon.java
@@ -49,6 +49,11 @@ public final class StartsDaemon implements Agent {
     public static final String GPG_HOME = ".gnupg";
 
     /**
+     * GPG secring environment variable.
+     */
+    private static final String GPG_SECRING = "GPG_SECRING";
+
+    /**
      * Paths to match.
      */
     private static final Array<String> PATHS = new Array<>(
@@ -164,20 +169,33 @@ public final class StartsDaemon implements Agent {
     }
 
     /**
+     * Check GPG secret key.
+     * @param key Secret key
+     * @return Secret key
+     * @throws IOException If the key is missing or too short
+     */
+    static String checkedSecring(final String key) throws IOException {
+        if (key == null || key.split("\n").length < 10) {
+            throw new IOException(
+                String.format(
+                    "GPG secret key is missing or too short in the %s environment variable: %s",
+                    StartsDaemon.GPG_SECRING,
+                    key
+                )
+            );
+        }
+        return key;
+    }
+
+    /**
      * Upload GPG secret key.
      * @param shell The shell
      * @throws IOException If fails
      */
     private void uploadGpgKey(final Shell shell) throws IOException {
-        final String secring = System.getenv("GPG_SECRING");
-        if (secring.split("\n").length < 10) {
-            throw new IOException(
-                String.format(
-                    "GPG secret key is too short in the GPG_SECRING environment variable: %s",
-                    secring
-                )
-            );
-        }
+        final String secring = StartsDaemon.checkedSecring(
+            System.getenv(StartsDaemon.GPG_SECRING)
+        );
         new Shell.Safe(shell).exec(
             "gpg --import",
             IOUtils.toInputStream(

--- a/src/test/java/com/rultor/agents/daemons/StartsDaemonTest.java
+++ b/src/test/java/com/rultor/agents/daemons/StartsDaemonTest.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2009-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.rultor.agents.daemons;
+
+import java.io.IOException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link StartsDaemon}.
+ *
+ * @since 2.0
+ */
+final class StartsDaemonTest {
+
+    /**
+     * StartsDaemon can reject missing GPG secring.
+     */
+    @Test
+    void rejectsMissingGpgSecring() {
+        MatcherAssert.assertThat(
+            "Missing GPG_SECRING should be reported without NPE",
+            Assertions.assertThrows(
+                IOException.class,
+                () -> StartsDaemon.checkedSecring(null)
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString("missing"),
+                Matchers.containsString("GPG_SECRING")
+            )
+        );
+    }
+}


### PR DESCRIPTION
Fixes #2323.

## Summary
- validate missing `GPG_SECRING` before splitting it in `StartsDaemon`
- keep the existing short-key `IOException` path, with a clearer missing-or-short message
- add a focused regression for the missing environment value

## Validation
- `mvn --errors --batch-mode -Dtest=StartsDaemonTest test` -> `1 test, 0 failures, 0 errors`
- `mvn --errors --batch-mode -DskipTests qulice:check -Pqulice` -> passed
- `git diff --check upstream/master...HEAD` -> passed
- `typos src/main/java/com/rultor/agents/daemons/StartsDaemon.java src/test/java/com/rultor/agents/daemons/StartsDaemonTest.java` -> passed
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found

I did not run a live daemon/GPG import; validation is limited to the focused unit regression and repository style gates above.
