### PR TITLE
#1918: Cover daemon tail limit

### DIFF
--- a/src/main/java/com/rultor/agents/daemons/EndsDaemon.java
+++ b/src/main/java/com/rultor/agents/daemons/EndsDaemon.java
@@ -45,6 +45,11 @@ public final class EndsDaemon extends AbstractAgent {
     public static final String HIGHLIGHTS_PREFIX = "RULTOR: ";
 
     /**
+     * Tail length limit.
+     */
+    static final int TAIL_LIMIT = 10_000;
+
+    /**
      * Ctor.
      */
     public EndsDaemon() {
@@ -72,15 +77,35 @@ public final class EndsDaemon extends AbstractAgent {
     }
 
     /**
+     * Build tail text.
+     * @param lines Output lines
+     * @return Tail text
+     */
+    static String tail(final List<Text> lines) {
+        return new Sub(
+            new Joined(
+                System.lineSeparator(),
+                new Skipped<>(
+                    Math.max(lines.size() - 60, 0),
+                    new ListOf<>(
+                        new Mapped<>(
+                            Text::asString,
+                            lines
+                        )
+                    )
+                )
+            ),
+            0,
+            EndsDaemon.TAIL_LIMIT
+        ).toString();
+    }
+
+    /**
      * End this daemon.
      * @param shell Shell
      * @param dir The dir
      * @return Directives
      * @throws IOException If fails
-     * @todo #1207:1h There is no limit of tail message (only shifting to
-     *  100_000 symbols), but TkDaemon has a limit of 100_000 symbols in buffer
-     *  It is better to have a restriction for the tail length, not about start
-     *  position.
      */
     private Iterable<Directive> end(final Shell shell,
         final String dir) throws IOException {
@@ -119,22 +144,7 @@ public final class EndsDaemon extends AbstractAgent {
             .add("tail")
             .set(
                 Xembler.escape(
-                    new Sub(
-                        new Joined(
-                            System.lineSeparator(),
-                            new Skipped<>(
-                                Math.max(lines.size() - 60, 0),
-                                new ListOf<>(
-                                    new Mapped<>(
-                                        Text::asString,
-                                        lines
-                                    )
-                                )
-                            )
-                        ),
-                        0,
-                        10_000
-                    ).toString()
+                    EndsDaemon.tail(lines)
                 )
             );
     }

--- a/src/main/java/com/rultor/agents/daemons/EndsDaemon.java
+++ b/src/main/java/com/rultor/agents/daemons/EndsDaemon.java
@@ -18,7 +18,6 @@ import lombok.ToString;
 import org.cactoos.Text;
 import org.cactoos.iterable.Filtered;
 import org.cactoos.iterable.Mapped;
-import org.cactoos.iterable.Skipped;
 import org.cactoos.list.ListOf;
 import org.cactoos.text.Joined;
 import org.cactoos.text.Split;
@@ -45,9 +44,9 @@ public final class EndsDaemon extends AbstractAgent {
     public static final String HIGHLIGHTS_PREFIX = "RULTOR: ";
 
     /**
-     * Tail length limit.
+     * Maximum daemon tail length.
      */
-    static final int TAIL_LIMIT = 10_000;
+    private static final int MAX_TAIL = 10_000;
 
     /**
      * Ctor.
@@ -77,26 +76,21 @@ public final class EndsDaemon extends AbstractAgent {
     }
 
     /**
-     * Build tail text.
+     * Build daemon tail.
      * @param lines Output lines
-     * @return Tail text
+     * @return Tail
      */
-    static String tail(final List<Text> lines) {
+    static String tail(final Iterable<Text> lines) {
+        final String out = new Joined(
+            System.lineSeparator(),
+            new Mapped<>(
+                Text::asString,
+                lines
+            )
+        ).toString();
         return new Sub(
-            new Joined(
-                System.lineSeparator(),
-                new Skipped<>(
-                    Math.max(lines.size() - 60, 0),
-                    new ListOf<>(
-                        new Mapped<>(
-                            Text::asString,
-                            lines
-                        )
-                    )
-                )
-            ),
-            0,
-            EndsDaemon.TAIL_LIMIT
+            out,
+            Math.max(out.length() - EndsDaemon.MAX_TAIL, 0)
         ).toString();
     }
 
@@ -143,9 +137,7 @@ public final class EndsDaemon extends AbstractAgent {
             .add("highlights").set(Xembler.escape(highlights)).up()
             .add("tail")
             .set(
-                Xembler.escape(
-                    EndsDaemon.tail(lines)
-                )
+                Xembler.escape(EndsDaemon.tail(lines))
             );
     }
 

--- a/src/test/java/com/rultor/agents/daemons/EndsDaemonTest.java
+++ b/src/test/java/com/rultor/agents/daemons/EndsDaemonTest.java
@@ -9,6 +9,9 @@ import com.rultor.spi.Agent;
 import com.rultor.spi.Talk;
 import java.io.IOException;
 import java.net.UnknownHostException;
+import org.cactoos.Text;
+import org.cactoos.list.ListOf;
+import org.cactoos.text.TextOf;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.xembly.Directives;
@@ -47,6 +50,23 @@ final class EndsDaemonTest {
         Assertions.assertThrows(
             UnknownHostException.class,
             () -> agent.execute(talk)
+        );
+    }
+
+    /**
+     * EndsDaemon should limit tail text.
+     */
+    @Test
+    void limitsTailLength() {
+        final String tail = EndsDaemon.tail(
+            new ListOf<Text>(
+                new TextOf("x".repeat(EndsDaemon.TAIL_LIMIT + 1))
+            )
+        );
+        Assertions.assertEquals(
+            EndsDaemon.TAIL_LIMIT,
+            tail.length(),
+            "Tail text must be limited"
         );
     }
 

--- a/src/test/java/com/rultor/agents/daemons/EndsDaemonTest.java
+++ b/src/test/java/com/rultor/agents/daemons/EndsDaemonTest.java
@@ -9,7 +9,6 @@ import com.rultor.spi.Agent;
 import com.rultor.spi.Talk;
 import java.io.IOException;
 import java.net.UnknownHostException;
-import org.cactoos.Text;
 import org.cactoos.list.ListOf;
 import org.cactoos.text.TextOf;
 import org.junit.jupiter.api.Assertions;
@@ -20,6 +19,7 @@ import org.xembly.Directives;
  * Tests for {@link EndsDaemon}.
  *
  * @since 1.2
+ * @checkstyle MagicNumber (500 lines)
  * @checkstyle MultipleStringLiterals (500 lines)
  */
 final class EndsDaemonTest {
@@ -54,19 +54,29 @@ final class EndsDaemonTest {
     }
 
     /**
-     * EndsDaemon should limit tail text.
+     * EndsDaemon limits tail by its final length.
      */
     @Test
-    void limitsTailLength() {
+    void limitsTailByLength() {
+        final String end = "tail-end";
         final String tail = EndsDaemon.tail(
-            new ListOf<Text>(
-                new TextOf("x".repeat(EndsDaemon.TAIL_LIMIT + 1))
+            new ListOf<>(
+                new TextOf(String.format("tail-start-%s", "x".repeat(12_000))),
+                new TextOf(end)
             )
         );
         Assertions.assertEquals(
-            EndsDaemon.TAIL_LIMIT,
+            10_000,
             tail.length(),
-            "Tail text must be limited"
+            "Tail should be capped by length"
+        );
+        Assertions.assertTrue(
+            tail.endsWith(end),
+            "Tail should preserve the end of stdout"
+        );
+        Assertions.assertFalse(
+            tail.contains("tail-start"),
+            "Tail should not keep the beginning when stdout is too long"
         );
     }
 


### PR DESCRIPTION
Summary:
- Removes the solved #1207 PDD from EndsDaemon.
- Builds the daemon tail from the full joined output and keeps the final 10,000 characters, so long output preserves the actual end instead of the beginning of the selected lines.
- Adds focused unit coverage proving the tail is capped and still ends with the newest stdout text.

Validation:
- mvn -q -Dtest=EndsDaemonTest test
- mvn -q -Dstyle.color=never -DskipTests -Pqulice qulice:check
- git diff --check upstream/master..HEAD
- git show --format= --no-ext-diff HEAD | gitleaks stdin --no-banner --redact --exit-code 1

Limitations:
- Full test suite was not run locally; validation was scoped to the affected unit test plus Qulice, diff, and secret gates.