### PR TITLE
#2323 guard against null GPG_SECRING in uploadGpgKey

### DIFF
--- a/src/main/java/com/rultor/agents/daemons/StartsDaemon.java
+++ b/src/main/java/com/rultor/agents/daemons/StartsDaemon.java
@@ -170,6 +170,11 @@ public final class StartsDaemon implements Agent {
      */
     private void uploadGpgKey(final Shell shell) throws IOException {
         final String secring = System.getenv("GPG_SECRING");
+        if (secring == null) {
+            throw new IOException(
+                "GPG_SECRING environment variable is not set"
+            );
+        }
         if (secring.split("\n").length < 10) {
             throw new IOException(
                 String.format(


### PR DESCRIPTION
Closes #2323.

`StartsDaemon.uploadGpgKey` reads `GPG_SECRING` from the environment and immediately calls `secring.split("\n")`. When the variable is unset, `System.getenv` returns `null` and the next line throws a raw `NullPointerException` inside `String.split`, masking the actual misconfiguration. A short null guard ahead of the existing length check turns that into an `IOException` that names the missing variable, so a first-time deployment without `GPG_SECRING` fails with a clear, actionable diagnostic.

Local checks against this branch: `mvn --batch-mode -q -DskipTests -Dinvoker.skip=true compile` succeeded; the diff is a five-line null guard with no behavior change for non-null inputs. Full `mvn install -Pqulice` could not be exercised locally because plugin dependency resolution is blocked in this environment, so the qulice and unit-test passes are left to CI.