### PR TITLE
#2352: close asset InputStreams in StartsDaemon.upload()

### DIFF
--- a/src/main/java/com/rultor/agents/daemons/StartsDaemon.java
+++ b/src/main/java/com/rultor/agents/daemons/StartsDaemon.java
@@ -203,15 +203,19 @@ public final class StartsDaemon implements Agent {
         try {
             for (final Map.Entry<String, InputStream> asset
                 : this.profile.assets().entrySet()) {
-                shell.exec(
-                    String.format(
-                        "cat > %s",
-                        Ssh.escape(String.format("%s/%s", dir, asset.getKey()))
-                    ),
-                    asset.getValue(),
-                    Logger.stream(Level.INFO, true),
-                    Logger.stream(Level.WARNING, true)
-                );
+                try (InputStream input = asset.getValue()) {
+                    shell.exec(
+                        String.format(
+                            "cat > %s",
+                            Ssh.escape(
+                                String.format("%s/%s", dir, asset.getKey())
+                            )
+                        ),
+                        input,
+                        Logger.stream(Level.INFO, true),
+                        Logger.stream(Level.WARNING, true)
+                    );
+                }
                 if (Logger.isInfoEnabled(this)) {
                     Logger.info(
                         this, "\"%s\" uploaded into %s in %[ms]s",

--- a/src/test/java/com/rultor/agents/daemons/StartsDaemonITCase.java
+++ b/src/test/java/com/rultor/agents/daemons/StartsDaemonITCase.java
@@ -124,6 +124,27 @@ final class StartsDaemonITCase {
     }
 
     /**
+     * StartsDaemon closes the asset stream after uploading it.
+     * @throws IOException In case of error
+     */
+    @Test
+    void closesAssetStreams() throws IOException {
+        try (
+            StartsDockerDaemon start =
+                new StartsDockerDaemon(Profile.EMPTY)
+        ) {
+            final StartsDaemonITCase.CloseAwareInputStream asset =
+                new StartsDaemonITCase.CloseAwareInputStream("rultor-asset");
+            StartsDaemonITCase.talk(start, asset);
+            MatcherAssert.assertThat(
+                "asset stream should be closed after it is uploaded",
+                asset.closed(),
+                Matchers.is(true)
+            );
+        }
+    }
+
+    /**
      * Creates a Talk object with basic parameters.
      * @param start Docker daemon starter
      * @return The basic Talk object for testing
@@ -131,6 +152,24 @@ final class StartsDaemonITCase {
      */
     private static Talk talk(final StartsDockerDaemon start)
         throws IOException {
+        return StartsDaemonITCase.talk(
+            start,
+            new ByteArrayInputStream(
+                // @checkstyle MagicNumber (1 line)
+                new byte[] {0, 1, 7, 8, 9, 10, 13, 20}
+            )
+        );
+    }
+
+    /**
+     * Creates a Talk object with a single named asset.
+     * @param start Docker daemon starter
+     * @param asset Stream to expose as the "file.bin" asset
+     * @return The basic Talk object for testing
+     * @throws IOException In case of error
+     */
+    private static Talk talk(final StartsDockerDaemon start,
+        final InputStream asset) throws IOException {
         Assumptions.assumeTrue(
             "true".equalsIgnoreCase(System.getProperty("run-docker-tests"))
         );
@@ -150,16 +189,45 @@ final class StartsDaemonITCase {
         final Profile profile = Mockito.mock(Profile.class);
         Mockito.doReturn(new XMLDocument("<p/>")).when(profile).read();
         Mockito.doReturn(
-            new ArrayMap<String, InputStream>().with(
-                "file.bin",
-                new ByteArrayInputStream(
-                    // @checkstyle MagicNumber (1 line)
-                    new byte[] {0, 1, 7, 8, 9, 10, 13, 20}
-                )
-            )
+            new ArrayMap<String, InputStream>().with("file.bin", asset)
         ).when(profile).assets();
         final Agent agent = new StartsDaemon(profile);
         agent.execute(talk);
         return talk;
+    }
+
+    /**
+     * Input stream that remembers whether it was closed.
+     *
+     * @since 1.78
+     */
+    private static final class CloseAwareInputStream
+        extends ByteArrayInputStream {
+
+        /**
+         * Whether close was called.
+         */
+        private transient boolean done;
+
+        /**
+         * Ctor.
+         * @param body Stream body
+         */
+        CloseAwareInputStream(final String body) {
+            super(body.getBytes(StandardCharsets.UTF_8));
+        }
+
+        @Override
+        public void close() {
+            this.done = true;
+        }
+
+        /**
+         * Check whether close was called.
+         * @return True if closed.
+         */
+        boolean closed() {
+            return this.done;
+        }
     }
 }


### PR DESCRIPTION
Closes #2352.

## Problem

`Profile.assets()` (`src/main/java/com/rultor/spi/Profile.java`) returns a `Map<String, InputStream>` whose values are raw `InputStream` instances owned by the caller. In `StartsDaemon.upload()` each value is piped to the remote shell via `Shell.exec(...)`, which consumes the stream but does **not** close it. The loop then discards the reference, so every asset declared in `.rultor.yml` leaks one `InputStream` per build start.

For the in-memory profile this is a cheap leak, but `GithubProfile.assets()` builds each value from `this.asset(...)` (file/network-backed), so the descriptors accumulate across builds.

## Fix

Wrap each asset value in a try-with-resources block so it is closed after it is piped to the shell, whatever the outcome:

```java
for (final Map.Entry<String, InputStream> asset
    : this.profile.assets().entrySet()) {
    try (InputStream input = asset.getValue()) {
        shell.exec(..., input, ...);
    }
    ...
}
```

This is the same pattern accepted for the sibling leak in `PfShell.key()` (#2324).

## Test

`StartsDaemonITCase` already drives the full upload path against a Dockerised SSH host with a mocked `Profile`. I added `closesAssetStreams()`, which exposes the asset as a `CloseAwareInputStream` and asserts it is closed once the daemon has run. The `talk(...)` helper was split into a small overload so the existing test and the new one share the directive setup. The new test is gated by the same `run-docker-tests` assumption as the rest of the ITCase.

Verified locally with `mvn test-compile qulice:check -Pqulice` (green).