### PR TITLE
#1135 make release tweets optional via profile flag

### DIFF
--- a/src/main/java/com/rultor/agents/Agents.java
+++ b/src/main/java/com/rultor/agents/Agents.java
@@ -314,6 +314,7 @@ public final class Agents {
                 new SafeAgent(
                     new Tweets(
                         this.github,
+                        profile,
                         new OAuthTwitter(
                             Env.read("Rultor-TwitterKey"),
                             Env.read("Rultor-TwitterSecret"),

--- a/src/main/java/com/rultor/agents/twitter/Tweets.java
+++ b/src/main/java/com/rultor/agents/twitter/Tweets.java
@@ -13,6 +13,7 @@ import com.jcabi.log.Logger;
 import com.jcabi.xml.XML;
 import com.rultor.agents.AbstractAgent;
 import com.rultor.agents.github.TalkIssues;
+import com.rultor.spi.Profile;
 import java.io.IOException;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -26,13 +27,18 @@ import org.xembly.Directives;
  */
 @Immutable
 @ToString
-@EqualsAndHashCode(callSuper = false, of = { "github", "twitter" })
+@EqualsAndHashCode(callSuper = false, of = { "github", "profile", "twitter" })
 public final class Tweets extends AbstractAgent {
 
     /**
      * GitHub.
      */
     private final transient GitHub github;
+
+    /**
+     * Profile of the project being released.
+     */
+    private final transient Profile profile;
 
     /**
      * Twitter.
@@ -42,14 +48,16 @@ public final class Tweets extends AbstractAgent {
     /**
      * Ctor.
      * @param ghub GitHub client
+     * @param prof Profile of the project being released
      * @param twt Twitter client
      */
-    public Tweets(final GitHub ghub, final Twitter twt) {
+    public Tweets(final GitHub ghub, final Profile prof, final Twitter twt) {
         super(
             "/talk/wire[github-repo and github-issue]",
             "/talk/request[@id and type='release' and success='true']"
         );
         this.github = ghub;
+        this.profile = prof;
         this.twitter = twt;
     }
 
@@ -58,7 +66,10 @@ public final class Tweets extends AbstractAgent {
         final XML req = xml.nodes("/talk/request").get(0);
         final Issue.Smart issue = new TalkIssues(this.github, xml).get();
         final Repo.Smart repo = new Repo.Smart(issue.repo());
-        if (!repo.isPrivate()) {
+        final String flag = new Profile.Defaults(this.profile).text(
+            "/p/entry[@key='release']/entry[@key='tweet']", "true"
+        );
+        if (!repo.isPrivate() && !"false".equalsIgnoreCase(flag)) {
             this.twitter.post(
                 Tweets.tweet(
                     repo, req.xpath("args/arg[@name='tag']/text()").get(0)

--- a/src/test/java/com/rultor/agents/twitter/TweetsTest.java
+++ b/src/test/java/com/rultor/agents/twitter/TweetsTest.java
@@ -8,6 +8,8 @@ import com.jcabi.github.Issue;
 import com.jcabi.github.Repo;
 import com.jcabi.github.Repos;
 import com.jcabi.github.mock.MkGitHub;
+import com.jcabi.xml.XMLDocument;
+import com.rultor.spi.Profile;
 import com.rultor.spi.Talk;
 import java.io.IOException;
 import java.util.UUID;
@@ -38,7 +40,7 @@ final class TweetsTest {
         );
         final Twitter twitter = Mockito.mock(Twitter.class);
         final Talk talk = TweetsTest.talk(repo, repo.issues().create("", ""));
-        new Tweets(repo.github(), twitter).execute(talk);
+        new Tweets(repo.github(), Profile.EMPTY, twitter).execute(talk);
         Mockito.verify(twitter).post(
             ArgumentMatchers.contains(repo.coordinates().repo())
         );
@@ -56,7 +58,7 @@ final class TweetsTest {
             )
         );
         final Twitter twitter = Mockito.mock(Twitter.class);
-        new Tweets(repo.github(), twitter).execute(
+        new Tweets(repo.github(), Profile.EMPTY, twitter).execute(
             TweetsTest.talk(repo, repo.issues().create("", ""))
         );
         Mockito.verify(twitter).post(
@@ -70,6 +72,30 @@ final class TweetsTest {
                 ).asString()
             )
         );
+    }
+
+    /**
+     * Tweets skips posting when the profile sets `release/tweet` to `false`.
+     * @throws Exception In case of error.
+     */
+    @Test
+    void skipsTweetWhenDisabledInProfile() throws Exception {
+        final Repo repo = new MkGitHub().repos().create(
+            new Repos.RepoCreate(
+                UUID.randomUUID().toString().replace("-", ""), false
+            )
+        );
+        final Twitter twitter = Mockito.mock(Twitter.class);
+        final Profile profile = new Profile.Fixed(
+            new XMLDocument(
+                "<p><entry key='release'><entry key='tweet'>false</entry></entry></p>"
+            )
+        );
+        new Tweets(repo.github(), profile, twitter).execute(
+            TweetsTest.talk(repo, repo.issues().create("", ""))
+        );
+        Mockito.verify(twitter, Mockito.never())
+            .post(ArgumentMatchers.anyString());
     }
 
     /**


### PR DESCRIPTION
Closes #1135.

Adds an opt-out for the release tweet. When the project's profile carries `release/tweet: false`, `Tweets.process` reads the flag through `Profile.Defaults.text("/p/entry[@key='release']/entry[@key='tweet']", "true")` and skips the `OAuthTwitter.post` call. The default stays `true`, so projects that never set the flag keep tweeting on every successful release. `Agents` is updated to pass the in-scope `Profile` through to `Tweets` at the existing release-tweet wiring site.

Local checks on Java 21 / Maven 3.9.11: `mvn --batch-mode --errors -DskipTests compile` builds clean; `mvn --batch-mode --errors -Dtest=TweetsTest test` runs all three TweetsTest cases green, including the new `skipsTweetWhenDisabledInProfile` that constructs a `Profile.Fixed` with `release/tweet=false` and verifies `OAuthTwitter.post` is never called.
