### PR TITLE
#1111 document optional title= argument in release command

### DIFF
--- a/src/jekyll/_posts/2014/jul/2014-07-13-basics.md
+++ b/src/jekyll/_posts/2014/jul/2014-07-13-basics.md
@@ -115,6 +115,13 @@ Then, in your script you get `$tag` environment variable,
 which will be set to `1.7`. Your script should change
 the version of the product to 1.7 and build it.
 
+An optional `title` argument overrides the GitHub release title,
+which otherwise defaults to the originating issue's title:
+
+{% highlight text %}
+@rultor release, tag=`1.7`, title=`Fixed memory leak in WebSocket pool`
+{% endhighlight %}
+
 This is how we do it in jcabi
 [`rultor.yml`](https://github.com/jcabi/jcabi/blob/master/.rultor.yml).
 For example:


### PR DESCRIPTION
The #1111 proposal — letting users override the GitHub release title from the
release comment — is already wired in code: `CommentsTag.title()` reads
`args/arg[@name='title']` and falls back to the issue title, the
`QnParametrized` parser turns `title=\`...\`` into that arg, and
`createsReleaseTitleFromTalk` in `CommentsTagTest` covers the path. Only the
documentation was missing.

The basics post now shows the optional `title=` argument next to the existing
`tag=` example, so users can see how to invoke it without reading the source.

This is a documentation-only change to a Jekyll post, no Java, no resources, no
tests touched. Local diff is seven added lines in
`src/jekyll/_posts/2014/jul/2014-07-13-basics.md`; no build or test command
applies to that file.

Closes #1111