### PR TITLE
Honor owner/* wildcards in the friends list

### DIFF
--- a/src/jekyll/_posts/2014/jul/2014-07-13-reference.md
+++ b/src/jekyll/_posts/2014/jul/2014-07-13-reference.md
@@ -83,6 +83,10 @@ friends:
   - jcabi/*
 {% endhighlight %}
 
+This list is read from the **default branch** of the repository that owns
+the assets. Names are matched without case sensitivity, and a name ending
+with an asterisk permits every repository of that GitHub account.
+
 You may also add `trustee` list there, in order to specify the list
 of GitHub users who are allowed to modify the `.rultor.yml` file in the
 repository, which is requesting the assets:

--- a/src/main/java/com/rultor/profiles/Friends.java
+++ b/src/main/java/com/rultor/profiles/Friends.java
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2009-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.rultor.profiles;
+
+import java.util.Collection;
+import java.util.Locale;
+import org.cactoos.iterable.Mapped;
+import org.cactoos.list.ListOf;
+
+/**
+ * Repositories that are allowed to use the assets of another repository.
+ *
+ * <p>They are listed in the {@code friends} section of {@code .rultor.yml},
+ * in the repository that owns the assets. Names are compared without
+ * case sensitivity. A name may end with an asterisk, which permits every
+ * repository of a GitHub account, as in {@code jcabi/*}.</p>
+ *
+ * @since 2.1
+ */
+final class Friends {
+
+    /**
+     * Names, in lower case.
+     */
+    private final Collection<String> names;
+
+    /**
+     * Ctor.
+     * @param items Names, as they are listed in .rultor.yml
+     */
+    Friends(final Iterable<String> items) {
+        this.names = new ListOf<>(
+            new Mapped<>(item -> item.toLowerCase(Locale.ENGLISH), items)
+        );
+    }
+
+    /**
+     * How many of them are there?
+     * @return Total count of names in the list
+     */
+    public int size() {
+        return this.names.size();
+    }
+
+    /**
+     * Is this repository among them?
+     * @param coords Coordinates of the repo, e.g. "yegor256/rultor"
+     * @return TRUE if the repo may use the assets
+     */
+    public boolean allow(final String coords) {
+        final String repo = coords.toLowerCase(Locale.ENGLISH);
+        boolean allowed = false;
+        for (final String name : this.names) {
+            if (name.equals(repo) || Friends.matches(name, repo)) {
+                allowed = true;
+                break;
+            }
+        }
+        return allowed;
+    }
+
+    /**
+     * Does the name with an asterisk cover this repository?
+     * @param name Name from the friends list, e.g. "jcabi/*"
+     * @param repo Coordinates of the repo, e.g. "jcabi/aspects"
+     * @return TRUE if it covers
+     */
+    private static boolean matches(final String name, final String repo) {
+        return name.endsWith("/*")
+            && repo.startsWith(name.substring(0, name.length() - 1));
+    }
+}

--- a/src/main/java/com/rultor/profiles/GithubProfile.java
+++ b/src/main/java/com/rultor/profiles/GithubProfile.java
@@ -150,28 +150,24 @@ final class GithubProfile implements Profile {
                 )
             );
         }
-        final Collection<String> friends = new ListOf<>(
-            new Mapped<>(
-                input -> input.toLowerCase(Locale.ENGLISH),
-                new YamlXML(
-                    new String(
-                        new Content.Smart(
-                            rpo.contents().get(GithubProfile.FILE)
-                        ).decoded(),
-                        StandardCharsets.UTF_8
-                    )
-                ).get().xpath("/p/entry[@key='friends']/item/text()")
-            )
+        final Friends friends = new Friends(
+            new YamlXML(
+                new String(
+                    new Content.Smart(
+                        rpo.contents().get(GithubProfile.FILE)
+                    ).decoded(),
+                    StandardCharsets.UTF_8
+                )
+            ).get().xpath("/p/entry[@key='friends']/item/text()")
         );
-        final String coords = this.repo.coordinates()
-            .toString().toLowerCase(Locale.ENGLISH);
-        if (!friends.contains(coords)) {
+        if (!friends.allow(this.repo.coordinates().toString())) {
             throw new Profile.ConfigException(
                 String.format(
                     // @checkstyle LineLength (1 line)
-                    "%s in %s doesn't allow %s to use its assets (there are %d friends), see http://doc.rultor.com/reference.html#assets",
+                    "%s in %s (branch %s) doesn't allow %s to use its assets (there are %d friends), see https://doc.rultor.com/reference.html#assets",
                     GithubProfile.FILE, rpo.coordinates(),
-                    this.repo.coordinates(), friends.size()
+                    new DefaultBranch(rpo), this.repo.coordinates(),
+                    friends.size()
                 )
             );
         }

--- a/src/test/java/com/rultor/profiles/FriendsTest.java
+++ b/src/test/java/com/rultor/profiles/FriendsTest.java
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2009-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.rultor.profiles;
+
+import org.cactoos.list.ListOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for ${@link Friends}.
+ *
+ * @since 2.1
+ */
+final class FriendsTest {
+
+    @Test
+    void allowsExactName() {
+        MatcherAssert.assertThat(
+            "Friend listed by its full name cannot be rejected",
+            new Friends(new ListOf<>("jeff/hello", "donald/bye"))
+                .allow("donald/bye"),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void allowsNameInDifferentCase() {
+        MatcherAssert.assertThat(
+            "Friend spelled in another case cannot be rejected",
+            new Friends(new ListOf<>("RoRoche/home")).allow("roroche/HOME"),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void allowsEntireAccount() {
+        MatcherAssert.assertThat(
+            "Asterisk cannot stop covering all repos of the account",
+            new Friends(new ListOf<>("jcabi/*")).allow("jcabi/aspects"),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void deniesAccountWithSimilarPrefix() {
+        MatcherAssert.assertThat(
+            "Asterisk cannot leak into a similarly named account",
+            new Friends(new ListOf<>("jcabi/*")).allow("jcabi-more/aspects"),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void deniesStranger() {
+        MatcherAssert.assertThat(
+            "Repo out of the list cannot be allowed",
+            new Friends(new ListOf<>("jeff/hello", "jcabi/*"))
+                .allow("donald/bye"),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void countsAllNames() {
+        MatcherAssert.assertThat(
+            "Every name in the list cannot go uncounted",
+            new Friends(new ListOf<>("jeff/hello", "jcabi/*")).size(),
+            Matchers.equalTo(2)
+        );
+    }
+}


### PR DESCRIPTION
The `friends` section of `.rultor.yml` now accepts a name ending with an
asterisk, so `jcabi/*` lets every repository of that account read the
assets. Exact names keep working and matching stays case-insensitive.
The matching itself moved into a small `Friends` class with its own tests.

The reference page has advertised `jcabi/*` since 2014, but the code behind
it has always been a plain `contains()` over the list, so a wildcard
silently granted nothing to anybody. That is what bit the reporter of #2397.

The error message now also names the branch the friends list was read from.
That branch is the default one of the repository owning the assets, which is
easy to mistake for the branch being built. Two things I deliberately left
alone: the existence check for the assets repo still uses the requesting
repo's branch name, which breaks when the two repos have differently named
default branches; and `GithubProfileTest` already sits at PMD's method
ceiling, so the wildcard tests live in `FriendsTest`.

Closes #2397