### PR TITLE
Fix Time ISO round-trip across JVM time zones

### DIFF
--- a/src/main/java/com/rultor/Time.java
+++ b/src/main/java/com/rultor/Time.java
@@ -7,7 +7,6 @@ package com.rultor;
 import com.jcabi.aspects.Immutable;
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -79,17 +78,13 @@ public final class Time {
     }
 
     private static Instant parse(final String date) {
-        final String txt;
-        if (date.endsWith("Z")) {
-            txt = date.substring(0, date.length() - 1);
-        } else {
-            txt = date;
-        }
         try {
             return LocalDateTime.parse(
-                txt,
-                DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss", Locale.US)
-            ).atZone(ZoneId.systemDefault()).toInstant();
+                date,
+                DateTimeFormatter.ofPattern(
+                    "yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US
+                )
+            ).toInstant(ZoneOffset.UTC);
         } catch (final DateTimeParseException ex) {
             throw new IllegalStateException(ex);
         }

--- a/src/test/java/com/rultor/TimeTest.java
+++ b/src/test/java/com/rultor/TimeTest.java
@@ -8,6 +8,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
+import java.util.TimeZone;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -26,11 +27,30 @@ final class TimeTest {
      */
     @Test
     void canParseValidTime() {
-        final String date = "2005-10-08T15:48:39";
+        final String date = "2005-10-08T15:48:39Z";
         Assertions.assertDoesNotThrow(
             () -> new Time(date),
             "Time should be able to create from date-time string"
         );
+    }
+
+    /**
+     * ISO value can be parsed independently of the default time zone.
+     */
+    @Test
+    void roundTripsIsoOutsideUtc() {
+        final TimeZone origin = TimeZone.getDefault();
+        final long millis = Instant.parse("2005-10-08T15:48:39Z").toEpochMilli();
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone("Asia/Tokyo"));
+            MatcherAssert.assertThat(
+                "ISO round-trip should preserve the instant",
+                new Time(new Time(millis).iso()).msec(),
+                Matchers.equalTo(millis)
+            );
+        } finally {
+            TimeZone.setDefault(origin);
+        }
     }
 
     /**
@@ -40,6 +60,7 @@ final class TimeTest {
     @ParameterizedTest
     @ValueSource(
         strings = {
+            "2005-10-08T15:48:39",
             "2005-10-0815:48:28",
             "2005-10-08",
             "15:48:28"


### PR DESCRIPTION
## Summary

- parse the exact `Z`-suffixed format emitted by `Time.iso()` as UTC instead of using the JVM default time zone
- add a deterministic `Asia/Tokyo` regression test proving that `Time` preserves the instant through an ISO round-trip
- reject timestamps without the required UTC designator while preserving the existing `IllegalStateException` error contract

## Validation

- `mvn -Dtest=TimeTest test` (10 tests, 0 failures)
- `mvn -DskipTests qulice:check -Pqulice` (262 Java files, 1014 rules)
- `mvn --errors --batch-mode clean install -Pqulice` (251 unit tests and 17 integration tests, 0 failures)

Fixes #2359

## AI assistance

Codex assisted with implementation and test drafting. I reviewed the changes and ran the targeted and full repository checks above.
