### PR TITLE
fix: close Profile.assets InputStream in PfShell.key()

### DIFF
--- a/src/main/java/com/rultor/agents/shells/PfShell.java
+++ b/src/main/java/com/rultor/agents/shells/PfShell.java
@@ -8,6 +8,7 @@ import com.jcabi.aspects.Immutable;
 import com.jcabi.ssh.Ssh;
 import com.rultor.spi.Profile;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import lombok.EqualsAndHashCode;
@@ -128,9 +129,9 @@ public final class PfShell {
                     String.format("Private SSH key not found at %s", path)
                 );
             }
-            try {
+            try (InputStream stream = this.profile.assets().get(path)) {
                 key = IOUtils.toString(
-                    this.profile.assets().get(path),
+                    stream,
                     StandardCharsets.UTF_8
                 );
             } catch (final IOException ex) {


### PR DESCRIPTION
## Summary

fix: close Profile.assets InputStream in PfShell.key()

## Changes

- IOUtils.toString left the asset stream open after reading the SSH key.
- Use try-with-resources so the stream is always closed.

Fixes #2324
