### PR TITLE
#2322: close the EC2 client after the call that needed it

### DIFF
--- a/src/main/java/com/rultor/agents/aws/StartsInstance.java
+++ b/src/main/java/com/rultor/agents/aws/StartsInstance.java
@@ -15,10 +15,10 @@ import java.util.Arrays;
 import lombok.ToString;
 import org.xembly.Directive;
 import org.xembly.Directives;
+import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.Instance;
 import software.amazon.awssdk.services.ec2.model.ResourceType;
 import software.amazon.awssdk.services.ec2.model.RunInstancesRequest;
-import software.amazon.awssdk.services.ec2.model.RunInstancesResponse;
 import software.amazon.awssdk.services.ec2.model.Tag;
 import software.amazon.awssdk.services.ec2.model.TagSpecification;
 
@@ -148,9 +148,10 @@ public final class StartsInstance extends AbstractAgent {
             "Starting a new AWS instance for '%s' (image=%s, type=%s, group=%s, subnet=%s)...",
             talk, this.image, itype, this.sgroup, this.subnet
         );
-        final RunInstancesResponse response =
-            this.api.aws().runInstances(request);
-        final Instance instance = response.instances().get(0);
+        final Instance instance;
+        try (Ec2Client client = this.api.aws()) {
+            instance = client.runInstances(request).instances().get(0);
+        }
         Logger.info(
             this,
             "Started a new AWS instance %s for '%s'",

--- a/src/main/java/com/rultor/agents/aws/TerminatesInstance.java
+++ b/src/main/java/com/rultor/agents/aws/TerminatesInstance.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import lombok.ToString;
 import org.xembly.Directive;
 import org.xembly.Directives;
+import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.TerminateInstancesRequest;
 
 /**
@@ -43,11 +44,13 @@ public final class TerminatesInstance extends AbstractAgent {
     @Override
     public Iterable<Directive> process(final XML xml) throws IOException {
         final String instance = xml.xpath("/talk/ec2/instance/text()").get(0);
-        this.api.aws().terminateInstances(
-            TerminateInstancesRequest.builder()
-                .instanceIds(instance)
-                .build()
-        );
+        try (Ec2Client client = this.api.aws()) {
+            client.terminateInstances(
+                TerminateInstancesRequest.builder()
+                    .instanceIds(instance)
+                    .build()
+            );
+        }
         Logger.info(
             this, "Successfully terminated %s instance of %s",
             instance, xml.xpath("/talk/@name").get(0)


### PR DESCRIPTION
`AwsEc2.aws()` builds a fresh `Ec2Client` on every call, and the client owns an HTTP client, a thread pool and a connection pool. Neither call site closed it, so every agent tick that started or terminated an instance leaked one.

Both now take it in a try-with-resources. Caching one on `AwsEc2` would work too, since the SDK v2 client is thread-safe, but that would keep a pool open for the life of the process to serve a call that happens once in a while.

Closes #2322
