### PR TITLE
#2325: keep the passphrase off a line the shell prints

### DIFF
--- a/src/main/java/com/rultor/agents/req/Decrypt.java
+++ b/src/main/java/com/rultor/agents/req/Decrypt.java
@@ -43,6 +43,13 @@ final class Decrypt {
 
     /**
      * Decrypt instructions.
+     *
+     * <p>The passphrase goes to gpg through a pipe and the tracing of the
+     * shell is turned off around it. The script these instructions land in
+     * runs under {@code set -ex}, so a passphrase written on the command
+     * line is printed by the shell itself into a build log that is public
+     * (#2325).</p>
+     *
      * @return Instructions
      * @throws IOException If fails
      */
@@ -64,13 +71,15 @@ final class Decrypt {
                     )
                 )
             );
+            commands.add("set +x");
             commands.add(
                 String.format(
                     String.join(
                         Decrypt.SPACE,
+                        "printf '%%s' %s |",
                         "gpg --no-tty --batch --verbose --decrypt",
                         "--ignore-mdc-error",
-                        "--passphrase %s %s > %s"
+                        "--passphrase-fd 0 %s > %s"
                     ),
                     Ssh.escape(
                         String.format("rultor-key:%s", this.profile.name())
@@ -79,6 +88,7 @@ final class Decrypt {
                     Ssh.escape(key)
                 )
             );
+            commands.add("set -x");
             commands.add(String.format("rm -rf %s ", Ssh.escape(enc)));
         }
         return commands;

--- a/src/test/java/com/rultor/agents/req/DecryptTest.java
+++ b/src/test/java/com/rultor/agents/req/DecryptTest.java
@@ -38,6 +38,26 @@ final class DecryptTest {
      * @throws Exception In case of error.
      */
     @Test
+    void keepsThePassphraseOutOfTheTrace() throws Exception {
+        final String script = new Joined(
+            DecryptTest.NEWLINE,
+            new Decrypt(
+                new Profile.Fixed(this.createTestProfileXml(), "test/test")
+            ).commands()
+        ).asString();
+        MatcherAssert.assertThat(
+            "The passphrase must not stand on a command line the shell traces",
+            script,
+            Matchers.not(Matchers.containsString("--passphrase '"))
+        );
+        MatcherAssert.assertThat(
+            "The tracing must be off while the passphrase is piped in",
+            script,
+            Matchers.containsString("set +x")
+        );
+    }
+
+    @Test
     void decryptsAssets(@TempDir final Path temp) throws Exception {
         final String script = new Joined(
             DecryptTest.NEWLINE,

--- a/src/test/java/com/rultor/agents/req/DecryptTest.java
+++ b/src/test/java/com/rultor/agents/req/DecryptTest.java
@@ -38,26 +38,6 @@ final class DecryptTest {
      * @throws Exception In case of error.
      */
     @Test
-    void keepsThePassphraseOutOfTheTrace() throws Exception {
-        final String script = new Joined(
-            DecryptTest.NEWLINE,
-            new Decrypt(
-                new Profile.Fixed(this.createTestProfileXml(), "test/test")
-            ).commands()
-        ).asString();
-        MatcherAssert.assertThat(
-            "The passphrase must not stand on a command line the shell traces",
-            script,
-            Matchers.not(Matchers.containsString("--passphrase '"))
-        );
-        MatcherAssert.assertThat(
-            "The tracing must be off while the passphrase is piped in",
-            script,
-            Matchers.containsString("set +x")
-        );
-    }
-
-    @Test
     void decryptsAssets(@TempDir final Path temp) throws Exception {
         final String script = new Joined(
             DecryptTest.NEWLINE,
@@ -106,6 +86,27 @@ final class DecryptTest {
                 StandardCharsets.UTF_8
             ),
             Matchers.startsWith("hello, world!")
+        );
+    }
+
+    /**
+     * Decrypt keeps the passphrase off any line the shell traces.
+     * @throws Exception In case of error.
+     */
+    @Test
+    void keepsThePassphraseOutOfTheTrace() throws Exception {
+        MatcherAssert.assertThat(
+            "The passphrase must be piped in with the tracing off, not written on a traced line",
+            new Joined(
+                DecryptTest.NEWLINE,
+                new Decrypt(
+                    new Profile.Fixed(this.createTestProfileXml(), "test/test")
+                ).commands()
+            ).asString(),
+            Matchers.allOf(
+                Matchers.not(Matchers.containsString("--passphrase '")),
+                Matchers.containsString("set +x")
+            )
         );
     }
 


### PR DESCRIPTION
The passphrase stood on the gpg command line, and `StartsDaemon` writes `set -ex -o pipefail` at the top of every script it uploads, so bash printed that line, passphrase and all, into a build log that is published. The passphrase is `rultor-key:<owner>/<repo>`, so one leaked log also gives away the shape for every other project.

It now goes to gpg through a pipe with `--passphrase-fd 0`, and the tracing is turned off around that one command and turned back on after it.

The test that would have caught this needs a real gpg and is skipped without one, so the new test reads the commands instead: no passphrase on a traced line, and the tracing off while it is piped.

Closes #2325
